### PR TITLE
opt arguments support http protocol (default use HTTP/1.1)

### DIFF
--- a/src/wrk.h
+++ b/src/wrk.h
@@ -66,7 +66,7 @@ static uint64_t time_us();
 static uint64_t rand64(tinymt64_t *, uint64_t);
 
 static char *extract_url_part(char *, struct http_parser_url *, enum http_parser_url_fields);
-static char *format_request(char *, char *, char *, char **);
+static char *format_request(int protocol, char *, char *, char *, char **);
 
 static int parse_args(struct config *, char **, char **, int, char **);
 static void print_stats_header();


### PR DESCRIPTION
1. add protocol arg.
2. fix gcc make warning in wrk.c 
   src/wrk.c:139:56: warning: format specifies type 'size_t' (aka 'unsigned long') but the argument has type
     'uint64_t' (aka 'unsigned long long') [-Wformat]
           fprintf(stderr, "unable to create thread %zu %s\n", i, msg);
