### PR TITLE
Pre-build the complete buffer of requests for pipelining

### DIFF
--- a/src/wrk.h
+++ b/src/wrk.h
@@ -51,6 +51,8 @@ typedef struct connection {
     int fd;
     uint64_t start;
     uint64_t pending;
+    // offset into req.size for the start of the unwritten bytes of this batch
+    int write_offset;
     char buf[RECVBUF];
 } connection;
 
@@ -64,6 +66,7 @@ static int calibrate(aeEventLoop *, long long, void *);
 static int sample_rate(aeEventLoop *, long long, void *);
 static int check_timeouts(aeEventLoop *, long long, void *);
 
+static int write_batch(connection *c);
 static void socket_writeable(aeEventLoop *, int, void *, int);
 static void socket_readable(aeEventLoop *, int, void *, int);
 static int request_complete(http_parser *);


### PR DESCRIPTION
There seems to be a limit of packages (framing overhead) and system calls which one can successfully send. This patch tries to optimize the number of packages send by pre-building the complete batch of pipelined requests into one big buffer.

Also, the write handling is improved so that successful writing doesn't rely any more on the send buffer size (and network condition). Instead, the request buffer is written in chunks when the network allows it.
