### PR TITLE
Pass port in. Host header should have the full Host:port.

### DIFF
--- a/scripts/wrk.lua
+++ b/scripts/wrk.lua
@@ -10,6 +10,7 @@ local wrk = {
 
 function wrk.format(method, path, headers, body)
    local host    = wrk.host
+   local port    = wrk.port
    local method  = method  or wrk.method
    local path    = path    or wrk.path
    local headers = headers or wrk.headers


### PR DESCRIPTION
My server uses the Host:port to decide who to serve a request.

wrk sends a Host header with only the host, leaving out the port.

This causes my server to respond with an error, as it cannot 
recognize a server based on just that host alone.

This one line fix fixes it.

Update issue #53 .
