### PR TITLE
expose 'WRK_SCRIPT_PATH' global variable to lua scripts

### DIFF
--- a/README
+++ b/README
@@ -35,6 +35,10 @@ Scripting
     response = function(status, headers, body)
     done     = function(summary, latency, requests)
 
+  wrk exposes two globals to your script:
+
+    WRK_SCRIPT_PATH = < path to your script file, set via -s >
+
     wrk = {
       scheme  = "http",
       host    = "localhost",

--- a/src/script.c
+++ b/src/script.c
@@ -59,6 +59,12 @@ void script_headers(lua_State *L, char **headers) {
     lua_pop(L, 2);
 }
 
+void script_source_path(lua_State *L, char *script) {
+    if (!script){ return; }
+    lua_pushstring(L, script);
+    lua_setglobal(L, "WRK_SCRIPT_PATH");
+}
+
 void script_init(lua_State *L, char *script, int argc, char **argv) {
     if (script && luaL_dofile(L, script)) {
         const char *cause = lua_tostring(L, -1);

--- a/src/script.h
+++ b/src/script.h
@@ -14,6 +14,7 @@ typedef struct {
 } buffer;
 
 lua_State *script_create(char *, char *, char *, char *);
+void script_source_path(lua_State *, char *);
 void script_headers(lua_State *, char **);
 size_t script_verify_request(lua_State *L);
 

--- a/src/wrk.c
+++ b/src/wrk.c
@@ -141,6 +141,7 @@ int main(int argc, char **argv) {
         t->stop_at     = stop_at;
 
         t->L = script_create(schema, host, port, path);
+        script_source_path(t->L, cfg.script);
         script_headers(t->L, headers);
         script_init(t->L, cfg.script, argc - optind, &argv[optind]);
 


### PR DESCRIPTION
Full disclosure: I'm a newb on multiple fronts here :-)

I am trying to extend wrk using the lua script option to do some basic url setup and configuration - pull urls from a list and load randomly or in sequence, etc. I want to treat these url lists (each representing a typical usage scenario for my app) as simple config data files. The simplest approach seemed to be to use lua's module system... but [unfortunately it isn't that sophisticated when it comes to lookup / pathing](http://stackoverflow.com/q/11714204/579167). Modules are assumed to be available in one of a series of pre-configured directories or, with some work, [relative to the requiring module](http://stackoverflow.com/a/9146653/579167). 

The problem is that a program running an embedded script doesn't have a way to set the `...` lua variable (typically, the path used to load the module) when loading and running a script. 

So, since wrk knows where to find the user's script, I just expose it as `WRK_SCRIPT_PATH`. Script authors can then use this value to maintain their relative module paths.

All feedback / suggestions welcome! Thanks for making such an awesome tool!