### PR TITLE
Make # of samples configurable, fix build on sunos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ LIBS    := -lpthread -lm -lcrypto -lssl
 TARGET  := $(shell uname -s | tr [A-Z] [a-z] 2>/dev/null || echo unknown)
 
 ifeq ($(TARGET), sunos)
-	CFLAGS += -D_PTHREADS -D_POSIX_C_SOURCE=200112L
+	CFLAGS += -D_PTHREADS -D_POSIX_C_SOURCE=200112L -DBSD_COMP
 	LIBS   += -lsocket
 else ifeq ($(TARGET), darwin)
 	LDFLAGS += -pagezero_size 10000 -image_base 100000000

--- a/src/wrk.c
+++ b/src/wrk.c
@@ -7,6 +7,7 @@ static struct config {
     struct addrinfo addr;
     uint64_t threads;
     uint64_t connections;
+    uint64_t samples;
     uint64_t duration;
     uint64_t timeout;
     uint64_t pipeline;
@@ -128,8 +129,8 @@ int main(int argc, char **argv) {
     cfg.addr = *addr;
 
     pthread_mutex_init(&statistics.mutex, NULL);
-    statistics.latency  = stats_alloc(SAMPLES);
-    statistics.requests = stats_alloc(SAMPLES);
+    statistics.latency  = stats_alloc(cfg.samples);
+    statistics.requests = stats_alloc(cfg.samples);
 
     thread *threads = zcalloc(cfg.threads * sizeof(thread));
     uint64_t connections = cfg.connections / cfg.threads;
@@ -542,6 +543,7 @@ static char *extract_url_part(char *url, struct http_parser_url *parser_url, enu
 static struct option longopts[] = {
     { "connections", required_argument, NULL, 'c' },
     { "duration",    required_argument, NULL, 'd' },
+    { "samples",     required_argument, NULL, 'S' },
     { "threads",     required_argument, NULL, 't' },
     { "script",      required_argument, NULL, 's' },
     { "header",      required_argument, NULL, 'H' },
@@ -558,16 +560,20 @@ static int parse_args(struct config *cfg, char **url, char **headers, int argc, 
     memset(cfg, 0, sizeof(struct config));
     cfg->threads     = 2;
     cfg->connections = 10;
+    cfg->samples     = 10000000;
     cfg->duration    = 10;
     cfg->timeout     = SOCKET_TIMEOUT_MS;
 
-    while ((c = getopt_long(argc, argv, "t:c:d:s:H:T:Lrv?", longopts, NULL)) != -1) {
+    while ((c = getopt_long(argc, argv, "t:c:S:d:s:H:T:Lrv?", longopts, NULL)) != -1) {
         switch (c) {
             case 't':
                 if (scan_metric(optarg, &cfg->threads)) return -1;
                 break;
             case 'c':
                 if (scan_metric(optarg, &cfg->connections)) return -1;
+                break;
+            case 'S':
+                if (scan_metric(optarg, &cfg->samples)) return -1;
                 break;
             case 'd':
                 if (scan_time(optarg, &cfg->duration)) return -1;

--- a/src/wrk.h
+++ b/src/wrk.h
@@ -16,7 +16,6 @@
 
 #define VERSION  "3.1.0"
 #define RECVBUF  8192
-#define SAMPLES  100000000
 
 #define SOCKET_TIMEOUT_MS   2000
 #define CALIBRATE_DELAY_MS  500


### PR DESCRIPTION
 - Make # of samples configurable. Default # samples is 100M, and
   wrk try to allocate 1.6GB memory block for statistics. This
   could be a problem on small systems/VMs without enough RAM.
   I made # of samples to be configurable via command line options
   (-S). Default # of samples is also changed to 10M, now wrk uses
   140MB for statistics which ls affordable for small-meory
   environments.

 - Fix build on sunos (SmartOS). SmartOS ioctl.h defines FIONREAD
   only when BSD_COMP is defined, so I added it in Makefile.