### PR TITLE
Fix compilation error on Ubuntu 13.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CFLAGS  := -std=c99 -Wall -O2 -D_REENTRANT
 LIBS    := -lpthread -lm -lcrypto -lssl
 
-TARGET  := $(shell uname -s | tr [A-Z] [a-z] 2>/dev/null || echo unknown)
+TARGET  := $(shell uname -s | tr '[A-Z]' '[a-z]' 2>/dev/null || echo unknown)
 
 ifeq ($(TARGET), sunos)
 	CFLAGS += -D_PTHREADS -D_POSIX_C_SOURCE=200112L


### PR DESCRIPTION
make fails for me like this without this:

 LINK wrk
 /usr/bin/ld: deps/luajit/src/libluajit.a(lj_clib.o): undefined reference to
 /lib/x86_64-linux-gnu/libdl.so.2: error adding symbols: DSO missing from co
 collect2: error: ld returned 1 exit status
 make: **\* [wrk] Error 1

 $ bash --version
 GNU bash, version 4.2.45(1)-release (x86_64-pc-linux-gnu)

 $ uname -s
 Linux
