### PR TITLE
Fix grammatical error in usage

### DIFF
--- a/src/wrk.c
+++ b/src/wrk.c
@@ -53,7 +53,7 @@ static void usage() {
            "        --timeout     <T>  Socket/request timeout     \n"
            "    -v, --version          Print version details      \n"
            "                                                      \n"
-           "  Numeric arguments may include a SI unit (1k, 1M, 1G)\n"
+           "  Numeric arguments may include an SI unit (1k, 1M, 1G)\n"
            "  Time arguments may include a time unit (2s, 2m, 2h)\n");
 }
 


### PR DESCRIPTION
When dealing with acronyms, you choose a/an based off the pronunciation of the first letter not whether the first letter is a consonant or not. Although it is unfortunate that the styling of the function isn't quite as beautiful.