### PR TITLE
Fix uninitialized thread->connections

### DIFF
--- a/src/wrk.c
+++ b/src/wrk.c
@@ -231,7 +231,7 @@ void *thread_main(void *arg) {
     thread *thread = arg;
     aeEventLoop *loop = thread->loop;
 
-    thread->cs = zmalloc(thread->connections * sizeof(connection));
+    thread->cs = zcalloc(thread->connections * sizeof(connection));
     tinymt64_init(&thread->rand, time_us());
     thread->latency = stats_alloc(100000);
 


### PR DESCRIPTION
thread->connections is allocated with zmalloc(), but most of it is left uninitialized.  This fails when code that assumes connection::headers and connection::body is zero-initialized.

Usually it works because early on malloc() returns zeroed memory.
