### PR TITLE
Allow for EOF to be read from socket without generating a read error

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -17,7 +17,7 @@ status sock_close(connection *c) {
 status sock_read(connection *c, size_t *n) {
     ssize_t r = read(c->fd, c->buf, sizeof(c->buf));
     *n = (size_t) r;
-    return r > 0 ? OK : ERROR;
+    return r >= 0 ? OK : ERROR;
 }
 
 status sock_write(connection *c, char *buf, size_t len, size_t *n) {


### PR DESCRIPTION
Howdy! First off, thanks for `wrk` - it's really nice to have a simple, scriptable HTTP load generator that doesn't have the letter 'J' in the name :)

Running on Mac OS X against a plain HTTP server running inside of a virtual machine, I'm consistently getting 100% of my requests marked as read errors. This doesn't happen when hitting remote servers, or when hitting servers running on localhost outside of the VM, but it always happens when hitting servers in the VM (yes, I realize that hitting a VM running on localhost is not ideal for load testing, but it is convenient while developing a test harness). Other tools (`curl`, `siege`, `ab`) have no issues with the same setup.

It looks like this is happening because the [`socket_readable`](https://github.com/wg/wrk/blob/master/src/wrk.c#L501) callback is being triggered one additional time at the end of each response body, when there are no actual bytes to read, just an EOF marker. `read(2)` is returning 0 in this case, indicating EOF, but this is being counted as a read error by `wrk`. It seems like everything else is working correctly, and it's not obvious to me that a 0 return value for `read(2)` in this usage really indicates an error (unless the connection is severed before the whole response body was read, but it looks like the ).

Allowing an EOF marker to be read by `read(2)` seems to work for me, but I'm not confident that it will correctly handle the case where the server closes the connection before finishing the HTTP response. Does this seem like a reasonable approach?