### PR TITLE
Add Lua script which allows testing connections through a web proxy.

### DIFF
--- a/scripts/proxy.lua
+++ b/scripts/proxy.lua
@@ -1,0 +1,10 @@
+-- execute as ./wrk [options] http://proxy:port -s proxy.lua -- http://target.website:port
+init = function(args)
+    target_url = args[1] -- proxy needs absolute URL
+end
+
+request = function()
+    req = wrk.format("GET", target_url)
+    print(req)
+    return req
+end

--- a/scripts/proxy.lua
+++ b/scripts/proxy.lua
@@ -4,7 +4,5 @@ init = function(args)
 end
 
 request = function()
-    req = wrk.format("GET", target_url)
-    print(req)
-    return req
+    return wrk.format("GET", target_url)
 end


### PR DESCRIPTION
This is a simple Lua script which allows testing connections through a web proxy. To make the connection go through an HTTP proxy use the following command line:

```
./wrk [options] http://proxy:port -s proxy.lua -- http://target.website:port
```
