### PR TITLE
Provide thread configuration to scripts and allow scripts to terminate event loop

### DIFF
--- a/README
+++ b/README
@@ -36,14 +36,22 @@ Scripting
     done     = function(summary, latency, requests)
 
     wrk = {
-      scheme  = "http",
-      host    = "localhost",
-      port    = nil,
-      method  = "GET",
-      path    = "/",
-      headers = {},
-      body    = nil
+      scheme   = "http",
+      host     = "localhost",
+      port     = nil,
+      method   = "GET",
+      path     = "/",
+      headers  = {},
+      body     = nil
+      threadid = 0,
+      nthreads = 0,
     }
+
+      The threadid and nthreads table members provide information about the
+      running thread and configuration to the lua script. wrk.threadid is a
+      Lua number, and its value represents the thread in which the script
+      is running. wrk.nthreads is a number that represents the number of
+      running threads in the process.
 
     function wrk.format(method, path, headers, body)
 
@@ -58,6 +66,12 @@ Scripting
   The init() function receives any extra command line arguments for the
   script. Script arguments must be separated from wrk arguments with "--"
   and scripts that override init() but not request() must call wrk.init()
+
+  The request() function, if returning nil instead of a valid HTTP request
+  line, will cause the current thread's event loop to exit.
+
+  The response() function is a boolean returning either true or false. If
+  false is returned, the current thread's event loop exits.
 
   The done() function receives a table containing result data, and two
   statistics objects representing the sampled per-request latency and

--- a/scripts/auth.lua
+++ b/scripts/auth.lua
@@ -15,4 +15,6 @@ response = function(status, headers, body)
       path  = "/resource"
       wrk.headers["X-Token"] = token
    end
+
+   return true
 end

--- a/scripts/thread-counter.lua
+++ b/scripts/thread-counter.lua
@@ -1,0 +1,22 @@
+-- example script demonstrating sharding requests across multiple threads
+-- and terminating only once all threads have completed their complement
+-- of requests
+
+local counter = 0
+local nobj = 60000000
+
+request = function()
+    path = "/" .. (counter + ((nobj / wrk.nthreads) * wrk.threadid))
+    counter = counter + 1
+    return wrk.format(nil, path)
+end
+
+local respcounter = 0
+response = function(status, headers, body)
+    respcounter = respcounter + 1
+    if respcounter == (nobj / wrk.nthreads) then
+        return false
+    end
+
+    return true
+end

--- a/src/script.c
+++ b/src/script.c
@@ -21,7 +21,7 @@ static const struct luaL_reg statslib[] = {
     { NULL,      NULL             }
 };
 
-lua_State *script_create(char *scheme, char *host, char *port, char *path) {
+lua_State *script_create(char *scheme, char *host, char *port, char *path, uint64_t *tid, uint64_t *nthr) {
     lua_State *L = luaL_newstate();
     luaL_openlibs(L);
     luaL_dostring(L, "wrk = require \"wrk\"");
@@ -31,11 +31,13 @@ lua_State *script_create(char *scheme, char *host, char *port, char *path) {
     lua_pop(L, 1);
 
     const table_field fields[] = {
-        { "scheme", LUA_TSTRING, scheme },
-        { "host",   LUA_TSTRING, host   },
-        { "port",   LUA_TSTRING, port   },
-        { "path",   LUA_TSTRING, path   },
-        { NULL,     0,           NULL   },
+        { "scheme",   LUA_TSTRING, scheme },
+        { "host",     LUA_TSTRING, host   },
+        { "port",     LUA_TSTRING, port   },
+        { "path",     LUA_TSTRING, path   },
+        { "threadid", LUA_TNUMBER, tid    },
+        { "nthreads", LUA_TNUMBER, nthr   },
+        { NULL,       0,           NULL   },
     };
 
     lua_getglobal(L, "wrk");

--- a/src/script.c
+++ b/src/script.c
@@ -104,8 +104,10 @@ bool script_response(lua_State *L, int status, buffer *headers, buffer *body) {
     lua_pushlstring(L, body->buffer, body->cursor - body->buffer);
     lua_call(L, 3, 0);
     if (lua_toboolean(L, 0)) {
+        lua_pop(L, 1);
         return true;
     } else {
+        lua_pop(L, 1);
         return false;
     }
 

--- a/src/script.c
+++ b/src/script.c
@@ -1,5 +1,6 @@
 // Copyright (C) 2013 - Will Glozer.  All rights reserved.
 
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 #include "script.h"
@@ -76,16 +77,20 @@ void script_init(lua_State *L, char *script, int argc, char **argv) {
     lua_call(L, 1, 0);
 }
 
-void script_request(lua_State *L, char **buf, size_t *len) {
+bool script_request(lua_State *L, char **buf, size_t *len) {
     lua_getglobal(L, "request");
     lua_call(L, 0, 1);
     const char *str = lua_tolstring(L, 1, len);
+    if (str == NULL) {
+        return false;
+    }
     *buf = realloc(*buf, *len);
     memcpy(*buf, str, *len);
     lua_pop(L, 1);
+    return true;
 }
 
-void script_response(lua_State *L, int status, buffer *headers, buffer *body) {
+bool script_response(lua_State *L, int status, buffer *headers, buffer *body) {
     lua_getglobal(L, "response");
     lua_pushinteger(L, status);
     lua_newtable(L);
@@ -98,6 +103,11 @@ void script_response(lua_State *L, int status, buffer *headers, buffer *body) {
 
     lua_pushlstring(L, body->buffer, body->cursor - body->buffer);
     lua_call(L, 3, 0);
+    if (lua_toboolean(L, 0)) {
+        return true;
+    } else {
+        return false;
+    }
 
     buffer_reset(headers);
     buffer_reset(body);

--- a/src/script.c
+++ b/src/script.c
@@ -102,17 +102,18 @@ bool script_response(lua_State *L, int status, buffer *headers, buffer *body) {
     }
 
     lua_pushlstring(L, body->buffer, body->cursor - body->buffer);
-    lua_call(L, 3, 0);
-    if (lua_toboolean(L, 0)) {
+    lua_call(L, 3, 1);
+
+    buffer_reset(headers);
+    buffer_reset(body);
+
+    if (lua_toboolean(L, -1)) {
         lua_pop(L, 1);
         return true;
     } else {
         lua_pop(L, 1);
         return false;
     }
-
-    buffer_reset(headers);
-    buffer_reset(body);
 }
 
 bool script_is_static(lua_State *L) {

--- a/src/script.c
+++ b/src/script.c
@@ -82,6 +82,7 @@ bool script_request(lua_State *L, char **buf, size_t *len) {
     lua_call(L, 0, 1);
     const char *str = lua_tolstring(L, 1, len);
     if (str == NULL) {
+        lua_pop(L, 1);
         return false;
     }
     *buf = realloc(*buf, *len);

--- a/src/script.h
+++ b/src/script.h
@@ -13,7 +13,7 @@ typedef struct {
     char  *cursor;
 } buffer;
 
-lua_State *script_create(char *, char *, char *, char *);
+lua_State *script_create(char *, char *, char *, char *, uint64_t *, uint64_t *);
 void script_headers(lua_State *, char **);
 size_t script_verify_request(lua_State *L);
 

--- a/src/script.h
+++ b/src/script.h
@@ -19,8 +19,8 @@ size_t script_verify_request(lua_State *L);
 
 void script_init(lua_State *, char *, int, char **);
 void script_done(lua_State *, stats *, stats *);
-void script_request(lua_State *, char **, size_t *);
-void script_response(lua_State *, int, buffer *, buffer *);
+bool script_request(lua_State *, char **, size_t *);
+bool script_response(lua_State *, int, buffer *, buffer *);
 
 bool script_is_static(lua_State *);
 bool script_want_response(lua_State *L);

--- a/src/wrk.c
+++ b/src/wrk.c
@@ -475,7 +475,7 @@ static void socket_writeable(aeEventLoop *loop, int fd, void *data, int mask) {
     connection *c = data;
     thread *thread = c->thread;
 
-    if (!c->written)
+    if (!c->written) {
 	if (cfg.dynamic && script_request(thread->L, &c->request, &c->length) == false) {
             aeStop(loop);
             return;

--- a/src/wrk.c
+++ b/src/wrk.c
@@ -139,11 +139,15 @@ int main(int argc, char **argv) {
     uint64_t stop_at     = time_us() + (cfg.duration * 1000000);
 
     for (uint64_t i = 0; i < cfg.threads; i++) {
-        thread *t = &threads[i];
+        thread *t      = &threads[i];
         t->loop        = aeCreateEventLoop(10 + cfg.connections * 3);
         t->connections = connections;
-        t->stop_at     = stop_at;
-        t->id = i;
+        t->id          = i;
+        if (cfg.duration) {
+            t->stop_at = stop_at;
+        } else {
+            t->stop_at = 0;
+        }
 
         t->L = script_create(schema, host, port, path, &t->id, &cfg.threads);
         script_headers(t->L, headers);
@@ -348,7 +352,7 @@ static int check_timeouts(aeEventLoop *loop, long long id, void *data) {
         }
     }
 
-    if (stop || now >= thread->stop_at) {
+    if (stop || (thread->stop_at > 0 && now >= thread->stop_at)) {
         aeStop(loop);
     }
 
@@ -424,7 +428,7 @@ static int response_complete(http_parser *parser) {
         c->state = FIELD;
     }
 
-    if (now >= thread->stop_at) {
+    if (thread->stop_at > 0 && now >= thread->stop_at) {
         aeStop(thread->loop);
         goto done;
     }
@@ -569,7 +573,7 @@ static int parse_args(struct config *cfg, char **url, char **headers, int argc, 
     memset(cfg, 0, sizeof(struct config));
     cfg->threads     = 2;
     cfg->connections = 10;
-    cfg->duration    = 10;
+    cfg->duration    = 0;
     cfg->timeout     = SOCKET_TIMEOUT_MS;
     cfg->bufsize     = RECVBUF;
 
@@ -612,7 +616,7 @@ static int parse_args(struct config *cfg, char **url, char **headers, int argc, 
         }
     }
 
-    if (optind == argc || !cfg->threads || !cfg->duration) return -1;
+    if (optind == argc || !cfg->threads || (!cfg->duration && !cfg->script)) return -1;
 
     if (!cfg->connections || cfg->connections < cfg->threads) {
         fprintf(stderr, "number of connections must be >= threads\n");

--- a/src/wrk.c
+++ b/src/wrk.c
@@ -550,6 +550,7 @@ static char *extract_url_part(char *url, struct http_parser_url *parser_url, enu
 }
 
 static struct option longopts[] = {
+    { "bufsize",     required_argument, NULL, 'b' },
     { "connections", required_argument, NULL, 'c' },
     { "duration",    required_argument, NULL, 'd' },
     { "threads",     required_argument, NULL, 't' },

--- a/src/wrk.c
+++ b/src/wrk.c
@@ -140,8 +140,9 @@ int main(int argc, char **argv) {
         t->loop        = aeCreateEventLoop(10 + cfg.connections * 3);
         t->connections = connections;
         t->stop_at     = stop_at;
+        t->id = i;
 
-        t->L = script_create(schema, host, port, path);
+        t->L = script_create(schema, host, port, path, &t->id, &cfg.threads);
         script_headers(t->L, headers);
         script_init(t->L, cfg.script, argc - optind, &argv[optind]);
 

--- a/src/wrk.c
+++ b/src/wrk.c
@@ -10,6 +10,7 @@ static struct config {
     uint64_t duration;
     uint64_t timeout;
     uint64_t pipeline;
+    uint64_t bufsize;
     bool     latency;
     bool     dynamic;
     char    *script;
@@ -43,6 +44,7 @@ static void handler(int sig) {
 static void usage() {
     printf("Usage: wrk <options> <url>                            \n"
            "  Options:                                            \n"
+           "    -b, --bufsize     <N>  Receive buffer size        \n"
            "    -c, --connections <N>  Connections to keep open   \n"
            "    -d, --duration    <T>  Duration of test           \n"
            "    -t, --threads     <N>  Number of threads to use   \n"
@@ -561,9 +563,13 @@ static int parse_args(struct config *cfg, char **url, char **headers, int argc, 
     cfg->connections = 10;
     cfg->duration    = 10;
     cfg->timeout     = SOCKET_TIMEOUT_MS;
+    cfg->bufsize     = RECVBUF;
 
-    while ((c = getopt_long(argc, argv, "t:c:d:s:H:T:Lrv?", longopts, NULL)) != -1) {
+    while ((c = getopt_long(argc, argv, "b:t:c:d:s:H:T:Lrv?", longopts, NULL)) != -1) {
         switch (c) {
+            case 'b':
+                if (scan_metric(optarg, &cfg->bufsize)) return -1;
+                break;
             case 't':
                 if (scan_metric(optarg, &cfg->threads)) return -1;
                 break;

--- a/src/wrk.h
+++ b/src/wrk.h
@@ -39,6 +39,7 @@ typedef struct {
     lua_State *L;
     errors errors;
     struct connection *cs;
+    uint64_t id;
 } thread;
 
 typedef struct connection {


### PR DESCRIPTION
Expose new `wrk.threadid` and `wrk.nthreads` variables to the lua state of
each thread. These represent the thread id the lua state is running on, and
the total number of running threads, respectively.

This allows lua scripts to make intelligent decisions about how to form and
balance requests across a number of distinct hosts and URI path endpoints.
For example, scripts could use the thread identifier in conjunction with a
per-luastate counter to force all requests to be unique and deterministic,
which is useful in load testing caching servers as well as pre-filling them.

Scripts can now also cause the event loop to terminate. This is done by
returning either `nil` from `request()` or `false` from `response()`. A new
example script shows how this functionality might be used in practice.

I also snuck in an option to increase the receive buffer size.