### PR TITLE
Fix Solaris-based build error

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -2,7 +2,12 @@
 
 #include <errno.h>
 #include <unistd.h>
-#include <sys/ioctl.h>
+#include <sys/ioctl.h
+
+/* On Solaris-based platforms, FIONREAD is defined in sys/filio.h */
+#if defined (__SVR4) && defined (__sun)
+#include <sys/filio.h>
+#endif
 
 #include "net.h"
 

--- a/src/net.c
+++ b/src/net.c
@@ -2,7 +2,7 @@
 
 #include <errno.h>
 #include <unistd.h>
-#include <sys/ioctl.h
+#include <sys/ioctl.h>
 
 /* On Solaris-based platforms, FIONREAD is defined in sys/filio.h */
 #if defined (__SVR4) && defined (__sun)


### PR DESCRIPTION
When building this software on Solaris, I received the following error:

    src/net.c:41:23: error: 'FIONREAD' undeclared (first use in this function)

After doing some research, I figured out `FIONREAD` is actually defined in `<sys/filio.h>` on Solaris-based machines.