### PR TITLE
Tracking 3xx, 4xx, 5xx separately

### DIFF
--- a/src/stats.h
+++ b/src/stats.h
@@ -6,12 +6,16 @@
 
 #define MAX(X, Y) ((X) > (Y) ? (X) : (Y))
 #define MIN(X, Y) ((X) < (Y) ? (X) : (Y))
+#define BETWEEN(X, A, B) ((X >= A) && (X <= B))
 
 typedef struct {
     uint32_t connect;
     uint32_t read;
     uint32_t write;
     uint32_t status;
+    uint32_t status_3xx;
+    uint32_t status_4xx;
+    uint32_t status_5xx;
     uint32_t timeout;
 } errors;
 


### PR DESCRIPTION
This is a very simplistic and perhaps even tedious way of tracking these
status codes.  I probably would prefer simple hash table to track the
exact status codes returned, but this suffices for now.

@wg I am making this pull request in case you feel this is a nice feature which others would benefit from, but I did this for myself :-) (thanks for an awesome tool btw, I use it a lot at work :-)