### PR TITLE
Proxy support for HTTP tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ else ifeq ($(TARGET), freebsd)
 endif
 
 SRC  := wrk.c net.c ssl.c aprintf.c stats.c script.c units.c \
-		ae.c zmalloc.c http_parser.c cli_options.c config.c
+		ae.c zmalloc.c http_parser.c cli_options.c config.c base64.c
 SRC_FILES := $(addprefix src/, $(filter-out wrk.c, $(SRC)) )
 
 TEST_FILES := $(shell find tests -name 'test_*.c')

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ else ifeq ($(TARGET), freebsd)
 endif
 
 SRC  := wrk.c net.c ssl.c aprintf.c stats.c script.c units.c \
-		ae.c zmalloc.c http_parser.c cli_options.c config.c base64.c
+		ae.c zmalloc.c http_parser.c cli_options.c config.c base64.c \
+		http.c
 SRC_FILES := $(addprefix src/, $(filter-out wrk.c, $(SRC)) )
 
 TEST_FILES := $(shell find tests -name 'test_*.c')

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,13 @@ else ifeq ($(TARGET), freebsd)
 endif
 
 SRC  := wrk.c net.c ssl.c aprintf.c stats.c script.c units.c \
-		ae.c zmalloc.c http_parser.c
+		ae.c zmalloc.c http_parser.c cli_options.c
+SRC_FILES := $(addprefix src/, $(filter-out wrk.c, $(SRC)) )
+
+TEST_FILES := $(shell find tests -name 'test_*.c')
+TEST_FILES := $(notdir $(TEST_FILES))
+TEST_SUITES := $(basename $(TEST_FILES))
+
 BIN  := wrk
 
 ODIR := obj
@@ -55,6 +61,18 @@ $(ODIR)/%.o : %.c
 $(LDIR)/libluajit.a:
 	@echo Building LuaJIT...
 	@$(MAKE) -C $(LDIR) BUILDMODE=static
+
+test:
+	mkdir -p build/tests
+	for test_suite in $(TEST_SUITES) ; do $(MAKE) $$test_suite ; done
+.PHONY: test
+
+test_%:
+	$(CC) $(CFLAGS) tests/$@.c $(SRC_FILES) $(LIBS) $(LDFLAGS) \
+		-o build/tests/$@ -g
+
+	build/tests/$@
+.PHONY: test_%
 
 .PHONY: all clean
 .SUFFIXES:

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ else ifeq ($(TARGET), freebsd)
 endif
 
 SRC  := wrk.c net.c ssl.c aprintf.c stats.c script.c units.c \
-		ae.c zmalloc.c http_parser.c cli_options.c
+		ae.c zmalloc.c http_parser.c cli_options.c config.c
 SRC_FILES := $(addprefix src/, $(filter-out wrk.c, $(SRC)) )
 
 TEST_FILES := $(shell find tests -name 'test_*.c')

--- a/src/base64.c
+++ b/src/base64.c
@@ -1,0 +1,35 @@
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <openssl/bio.h>
+#include <openssl/evp.h>
+#include <openssl/buffer.h>
+
+char*
+base64_encode(const char* buff, size_t len)
+{
+	BUF_MEM *buff_ptr = NULL;
+
+	BIO* b64 = BIO_new(BIO_f_base64());
+	BIO* bmem = BIO_new(BIO_s_mem());
+	BIO* bio = BIO_push(b64, bmem);
+
+	// Ignore newlines - write everything in one line.
+	BIO_set_flags(bio, BIO_FLAGS_BASE64_NO_NL);
+	BIO_write(bio, buff, len);
+	BIO_flush(bio);
+
+	BIO_get_mem_ptr(bio, &buff_ptr);
+	BIO_set_close(bio, BIO_NOCLOSE);
+	BIO_free_all(bio);
+
+	char *encoded_buff = (char *)malloc(buff_ptr->length);
+	if (encoded_buff == NULL) {
+		return NULL;
+	}
+
+	memcpy(encoded_buff, buff_ptr->data, buff_ptr->length);
+
+	return encoded_buff;
+}

--- a/src/base64.h
+++ b/src/base64.h
@@ -1,0 +1,14 @@
+#ifndef WRK_BASE64_H
+#define WRK_BASE64_H
+
+#include <stddef.h>
+
+/**
+ * Encode the specified buffer to base64.
+ *
+ * @return pointer to encoded buffer in base64. Receiver must free() this
+ *	pointer.
+ */
+char* base64_encode(const char* buff, size_t len);
+
+#endif /* WRK_BASE64_H */

--- a/src/cli_options.c
+++ b/src/cli_options.c
@@ -10,6 +10,65 @@
 #include "units.h"
 #include "script.h"
 
+/**
+ * @param proxy_url Proxy server URL in format '1.2.3.4:8000'.
+ * @return 0 on success, -1 on error.
+ */
+static int
+parse_proxy_url(const char* proxy_url, struct config* cfg)
+{
+        char url[256] = {0};
+        strcpy(url, proxy_url);
+
+        const char* addr = strtok(url, ":");
+        if (addr == NULL) {
+             fprintf(stderr, "Bad proxy URL format: %s. "
+                 "Expected: '1.2.3.4:8080\n", proxy_url);
+             return -1;
+        }
+
+        const char* port = strtok(NULL, ":");
+        if (port == NULL) {
+            fprintf(stderr, "Failed to parse proxy port from '%s'\n",
+                 proxy_url);
+            return -1;
+        }
+
+        strcpy(cfg->proxy_addr, addr);
+        strcpy(cfg->proxy_port, port);
+
+        return 0;
+}
+
+/**
+ * @return 0 on success, -1 on error.
+ */
+static int
+parse_proxy_user_pass(const char* proxy_user_pass, struct config* cfg)
+{
+        char user_pass[256] = {0};
+        strcpy(user_pass, proxy_user_pass);
+
+        const char* username = strtok(user_pass, ":");
+        if (username == NULL) {
+             fprintf(stderr, "Bad proxy user:password format: %s. "
+                 "Expected: 'username:password\n", proxy_user_pass);
+             return -1;
+        }
+
+        const char* password = strtok(NULL, ":");
+        if (password == NULL) {
+            fprintf(stderr, "Failed to parse proxy user password from '%s'\n",
+                 proxy_user_pass);
+            return -1;
+        }
+
+        strcpy(cfg->proxy_username, username);
+        strcpy(cfg->proxy_user_password, password);
+
+        return 0;
+}
+
 static struct option longopts[] = {
     { "connections", required_argument, NULL, 'c' },
     { "duration",    required_argument, NULL, 'd' },
@@ -18,6 +77,8 @@ static struct option longopts[] = {
     { "header",      required_argument, NULL, 'H' },
     { "latency",     no_argument,       NULL, 'L' },
     { "timeout",     required_argument, NULL, 'T' },
+    { "proxy",       required_argument, NULL, 'x' },
+    { "proxy-user",  required_argument, NULL, 'U' },
     { "help",        no_argument,       NULL, 'h' },
     { "version",     no_argument,       NULL, 'v' },
     { NULL,          0,                 NULL,  0  }
@@ -26,6 +87,8 @@ static struct option longopts[] = {
 int parse_args(struct config *cfg, char **url, struct http_parser_url *parts, char **headers, int argc, char **argv) {
     char **header = headers;
     int c;
+    char *proxy_url = NULL;
+    char *proxy_user_pass = NULL;
 
     memset(cfg, 0, sizeof(struct config));
     cfg->threads     = 2;
@@ -33,7 +96,7 @@ int parse_args(struct config *cfg, char **url, struct http_parser_url *parts, ch
     cfg->duration    = 10;
     cfg->timeout     = SOCKET_TIMEOUT_MS;
 
-    while ((c = getopt_long(argc, argv, "t:c:d:s:H:T:Lrv?", longopts, NULL)) != -1) {
+    while ((c = getopt_long(argc, argv, "t:c:d:s:H:T:x:U:Lrv?", longopts, NULL)) != -1) {
         switch (c) {
             case 't':
                 if (scan_metric(optarg, &cfg->threads)) return -1;
@@ -61,6 +124,12 @@ int parse_args(struct config *cfg, char **url, struct http_parser_url *parts, ch
                 printf("wrk %s [%s] ", VERSION, aeGetApiName());
                 printf("Copyright (C) 2012 Will Glozer\n");
                 break;
+            case 'x':
+                proxy_url = optarg;
+                break;
+            case 'U':
+                proxy_user_pass = optarg;
+                break;
             case 'h':
             case '?':
             case ':':
@@ -79,6 +148,18 @@ int parse_args(struct config *cfg, char **url, struct http_parser_url *parts, ch
     if (!cfg->connections || cfg->connections < cfg->threads) {
         fprintf(stderr, "number of connections must be >= threads\n");
         return -1;
+    }
+
+    if (proxy_url != NULL) {
+        if (parse_proxy_url(proxy_url, cfg) != 0) {
+            return -1;
+        }
+    }
+
+    if (proxy_user_pass != NULL) {
+        if (parse_proxy_user_pass(proxy_user_pass, cfg) != 0) {
+            return -1;
+        }
     }
 
     *url    = argv[optind];

--- a/src/cli_options.c
+++ b/src/cli_options.c
@@ -1,0 +1,88 @@
+#include <getopt.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "cli_options.h"
+#include "config.h"
+#include "http_parser.h"
+#include "wrk.h"
+#include "units.h"
+#include "script.h"
+
+static struct option longopts[] = {
+    { "connections", required_argument, NULL, 'c' },
+    { "duration",    required_argument, NULL, 'd' },
+    { "threads",     required_argument, NULL, 't' },
+    { "script",      required_argument, NULL, 's' },
+    { "header",      required_argument, NULL, 'H' },
+    { "latency",     no_argument,       NULL, 'L' },
+    { "timeout",     required_argument, NULL, 'T' },
+    { "help",        no_argument,       NULL, 'h' },
+    { "version",     no_argument,       NULL, 'v' },
+    { NULL,          0,                 NULL,  0  }
+};
+
+int parse_args(struct config *cfg, char **url, struct http_parser_url *parts, char **headers, int argc, char **argv) {
+    char **header = headers;
+    int c;
+
+    memset(cfg, 0, sizeof(struct config));
+    cfg->threads     = 2;
+    cfg->connections = 10;
+    cfg->duration    = 10;
+    cfg->timeout     = SOCKET_TIMEOUT_MS;
+
+    while ((c = getopt_long(argc, argv, "t:c:d:s:H:T:Lrv?", longopts, NULL)) != -1) {
+        switch (c) {
+            case 't':
+                if (scan_metric(optarg, &cfg->threads)) return -1;
+                break;
+            case 'c':
+                if (scan_metric(optarg, &cfg->connections)) return -1;
+                break;
+            case 'd':
+                if (scan_time(optarg, &cfg->duration)) return -1;
+                break;
+            case 's':
+                cfg->script = optarg;
+                break;
+            case 'H':
+                *header++ = optarg;
+                break;
+            case 'L':
+                cfg->latency = true;
+                break;
+            case 'T':
+                if (scan_time(optarg, &cfg->timeout)) return -1;
+                cfg->timeout *= 1000;
+                break;
+            case 'v':
+                printf("wrk %s [%s] ", VERSION, aeGetApiName());
+                printf("Copyright (C) 2012 Will Glozer\n");
+                break;
+            case 'h':
+            case '?':
+            case ':':
+            default:
+                return -1;
+        }
+    }
+
+    if (optind == argc || !cfg->threads || !cfg->duration) return -1;
+
+    if (!script_parse_url(argv[optind], parts)) {
+        fprintf(stderr, "invalid URL: %s\n", argv[optind]);
+        return -1;
+    }
+
+    if (!cfg->connections || cfg->connections < cfg->threads) {
+        fprintf(stderr, "number of connections must be >= threads\n");
+        return -1;
+    }
+
+    *url    = argv[optind];
+    *header = NULL;
+
+    return 0;
+}

--- a/src/cli_options.h
+++ b/src/cli_options.h
@@ -1,0 +1,15 @@
+#ifndef WRK_CLI_OPTIONS
+#define WRK_CLI_OPTIONS
+
+struct http_parser_url;
+struct config;
+
+/**
+ * @param cfg config structure filled with parsed options.
+ * @param url target URL.
+ * @return 0 on success, -1 on error.
+ */
+int parse_args(struct config *cfg, char **url, struct http_parser_url *parts,
+    char **headers, int argc, char **argv);
+
+#endif /* WRK_CLI_OPTIONS */

--- a/src/config.c
+++ b/src/config.c
@@ -1,0 +1,22 @@
+#include <stdbool.h>
+
+#include "config.h"
+
+static bool
+string_empty(const char* str)
+{
+	return (str == NULL) || (str[0] == '\0');
+}
+
+bool
+config_proxy_set(const struct config* cfg)
+{
+	return !string_empty(cfg->proxy_addr) && !string_empty(cfg->proxy_port);
+}
+
+bool
+config_proxy_auth_set(const struct config* cfg)
+{
+	return !string_empty(cfg->proxy_username)
+		&& !string_empty(cfg->proxy_user_password);
+}

--- a/src/config.h
+++ b/src/config.h
@@ -30,6 +30,10 @@ struct config {
     bool     dynamic;
     bool     latency;
     char    *script;
+    char     proxy_addr[256];
+    char     proxy_port[16];
+    char     proxy_username[256];
+    char     proxy_user_password[256];
     SSL_CTX *ctx;
 };
 

--- a/src/config.h
+++ b/src/config.h
@@ -37,4 +37,14 @@ struct config {
     SSL_CTX *ctx;
 };
 
+/**
+ * Checks if proxy address and port are set in the specified config structure.
+ */
+bool config_proxy_set(const struct config* cfg);
+
+/**
+ * Checks if proxy authentication data is set: username and password.
+ */
+bool config_proxy_auth_set(const struct config* cfg);
+
 #endif /* CONFIG_H */

--- a/src/config.h
+++ b/src/config.h
@@ -14,4 +14,23 @@
 #include <sys/time.h>
 #endif
 
+#include <stdint.h>
+#include <stdbool.h>
+
+#include <openssl/ssl.h>
+
+
+struct config {
+    uint64_t connections;
+    uint64_t duration;
+    uint64_t threads;
+    uint64_t timeout;
+    uint64_t pipeline;
+    bool     delay;
+    bool     dynamic;
+    bool     latency;
+    char    *script;
+    SSL_CTX *ctx;
+};
+
 #endif /* CONFIG_H */

--- a/src/http.c
+++ b/src/http.c
@@ -61,3 +61,16 @@ done:
 
 	return retval;
 }
+
+void
+http_append_header(char** headers, char* header)
+{
+	while (*headers != NULL) {
+		++headers;
+	}
+
+	*headers = header;
+
+	++headers;
+	*headers = NULL;
+}

--- a/src/http.c
+++ b/src/http.c
@@ -1,0 +1,63 @@
+#include <string.h>
+#include <stdlib.h>
+#include <stddef.h>
+
+#include "http.h"
+#include "base64.h"
+
+char*
+http_make_proxy_basic_auth_header(const char* username,
+	const char* password)
+{
+	char* retval = NULL;
+	char* auth_data_base64 = NULL;
+	char* proxy_auth_header = NULL;
+
+	size_t username_len = strlen(username);
+	size_t password_len = strlen(password);
+
+	char* auth_data = (char*)malloc(username_len + password_len + 2);
+	if (auth_data == NULL) {
+		goto done;
+	}
+
+	// Make "username:password" pattern.
+	strncpy(auth_data, username, username_len);
+	auth_data[username_len] = ':';
+	auth_data[username_len + 1] = '\0';
+	strncat(auth_data, password, password_len);
+
+	// Encode "username:password" to base64.
+	size_t auth_data_len = username_len + password_len + 1;
+	auth_data_base64 = base64_encode(auth_data, auth_data_len);
+	if (auth_data_base64 == NULL) {
+		goto done;
+	}
+
+	// Construct proxy auth header.
+	char header_prefix[] = "Proxy-Authorization: Basic ";
+	proxy_auth_header = (char*)malloc(sizeof(header_prefix)
+		+ strlen(auth_data_base64));
+	if (proxy_auth_header == NULL) {
+		goto done;
+	}
+
+	strcpy(proxy_auth_header, header_prefix);
+	strcat(proxy_auth_header, auth_data_base64);
+
+	retval = proxy_auth_header;
+	proxy_auth_header = NULL;
+
+done:
+	if (auth_data != NULL) {
+		free(auth_data);
+		auth_data = NULL;
+	}
+
+	if (auth_data_base64 != NULL) {
+		free(auth_data_base64);
+		auth_data_base64 = NULL;
+	}
+
+	return retval;
+}

--- a/src/http.h
+++ b/src/http.h
@@ -1,7 +1,6 @@
 #ifndef WRK_HTTP_H
 #define WRK_HTTP_H
 
-
 /**
  * Constructs HTTP proxy basic authorization header. E.g.
  *	Proxy-Authorization: Basic 98sdj90zxxcZZ==
@@ -12,5 +11,19 @@
  */
 char* http_make_proxy_basic_auth_header(const char* username,
 	const char* password);
+
+/**
+ * Appends specified header to the header list.
+ * Header list must have enough slots allocated for the extra pointer.
+ *
+ * NOTE: headers data structure should be replaced with something more
+ * flexible and safe. Use this function until refactoring is done.
+ * Also appending header pointer to the header list, its unclear who is
+ * responsible for free'ing up the memory.
+ *
+ * @param headers array of pointers to HTTP header strings. NULL pointer
+ *	terminates the list.
+ */
+void http_append_header(char** headers, char* header);
 
 #endif /* WRK_HTTP_H */

--- a/src/http.h
+++ b/src/http.h
@@ -1,0 +1,16 @@
+#ifndef WRK_HTTP_H
+#define WRK_HTTP_H
+
+
+/**
+ * Constructs HTTP proxy basic authorization header. E.g.
+ *	Proxy-Authorization: Basic 98sdj90zxxcZZ==
+ *
+ * You must free() the returned header string.
+ *
+ * @return pointer to constructed header on success. NULL on error.
+ */
+char* http_make_proxy_basic_auth_header(const char* username,
+	const char* password);
+
+#endif /* WRK_HTTP_H */

--- a/src/script.c
+++ b/src/script.c
@@ -45,10 +45,17 @@ static const struct luaL_reg threadlib[] = {
     { NULL,         NULL                   }
 };
 
-lua_State *script_create(char *file, char *url, char **headers) {
+lua_State *script_create(char *file, char *url, char **headers,
+    bool load_wrk) {
+
     lua_State *L = luaL_newstate();
     luaL_openlibs(L);
-    (void) luaL_dostring(L, "wrk = require \"wrk\"");
+
+    if (load_wrk) {
+        (void) luaL_dostring(L, "wrk = require \"wrk\"");
+    } else {
+        (void) luaL_dostring(L, "wrk = {}");
+    }
 
     luaL_newmetatable(L, "wrk.addr");
     luaL_register(L, NULL, addrlib);

--- a/src/script.c
+++ b/src/script.c
@@ -46,7 +46,7 @@ static const struct luaL_reg threadlib[] = {
 };
 
 lua_State *script_create(char *file, char *url, char **headers,
-    bool load_wrk) {
+    bool load_wrk, bool proxy_set) {
 
     lua_State *L = luaL_newstate();
     luaL_openlibs(L);
@@ -66,9 +66,11 @@ lua_State *script_create(char *file, char *url, char **headers,
 
     struct http_parser_url parts = {};
     script_parse_url(url, &parts);
-    char *path = "/";
 
-    if (parts.field_set & (1 << UF_PATH)) {
+    char *path = "/";
+    if (proxy_set) {
+        path = url;
+    } else if (parts.field_set & (1 << UF_PATH)) {
         path = &url[parts.field_data[UF_PATH].off];
     }
 

--- a/src/script.h
+++ b/src/script.h
@@ -9,7 +9,14 @@
 #include "stats.h"
 #include "wrk.h"
 
-lua_State *script_create(char *, char *, char **);
+/**
+ * Create new lua virtual machine setup with wrk test variables.
+ *
+ * @param load_wrk if true "wrk.lua" is imported from created lua VM. This
+ *	is undesired behavior during tests.
+ * @return pointer to created lua VM on success. NULL on error.
+ */
+lua_State *script_create(char *, char *, char **, bool load_wrk);
 
 bool script_resolve(lua_State *, char *, char *);
 void script_setup(lua_State *, thread *);

--- a/src/script.h
+++ b/src/script.h
@@ -14,9 +14,11 @@
  *
  * @param load_wrk if true "wrk.lua" is imported from created lua VM. This
  *	is undesired behavior during tests.
+ * @param proxy_set if true sets global lua variable "wrk.path" to url.
  * @return pointer to created lua VM on success. NULL on error.
  */
-lua_State *script_create(char *, char *, char **, bool load_wrk);
+lua_State *script_create(char *, char *, char **, bool load_wrk,
+	bool proxy_set);
 
 bool script_resolve(lua_State *, char *, char *);
 void script_setup(lua_State *, thread *);

--- a/src/wrk.c
+++ b/src/wrk.c
@@ -82,7 +82,7 @@ int main(int argc, char **argv) {
     statistics.requests = stats_alloc(MAX_THREAD_RATE_S);
     thread *threads     = zcalloc(cfg.threads * sizeof(thread));
 
-    lua_State *L = script_create(cfg.script, url, headers, true);
+    lua_State *L = script_create(cfg.script, url, headers, true, false);
     if (!script_resolve(L, host, service)) {
         char *msg = strerror(errno);
         fprintf(stderr, "unable to connect to %s:%s %s\n", host, service, msg);
@@ -94,7 +94,7 @@ int main(int argc, char **argv) {
         t->loop        = aeCreateEventLoop(10 + cfg.connections * 3);
         t->connections = cfg.connections / cfg.threads;
 
-        t->L = script_create(cfg.script, url, headers, true);
+        t->L = script_create(cfg.script, url, headers, true, false);
         script_init(L, t, argc - optind, &argv[optind]);
 
         if (i == 0) {

--- a/src/wrk.c
+++ b/src/wrk.c
@@ -4,6 +4,7 @@
 #include "script.h"
 #include "main.h"
 #include "config.h"
+#include "cli_options.h"
 
 static struct config cfg;
 
@@ -449,83 +450,6 @@ static char *copy_url_part(char *url, struct http_parser_url *parts, enum http_p
     }
 
     return part;
-}
-
-static struct option longopts[] = {
-    { "connections", required_argument, NULL, 'c' },
-    { "duration",    required_argument, NULL, 'd' },
-    { "threads",     required_argument, NULL, 't' },
-    { "script",      required_argument, NULL, 's' },
-    { "header",      required_argument, NULL, 'H' },
-    { "latency",     no_argument,       NULL, 'L' },
-    { "timeout",     required_argument, NULL, 'T' },
-    { "help",        no_argument,       NULL, 'h' },
-    { "version",     no_argument,       NULL, 'v' },
-    { NULL,          0,                 NULL,  0  }
-};
-
-static int parse_args(struct config *cfg, char **url, struct http_parser_url *parts, char **headers, int argc, char **argv) {
-    char **header = headers;
-    int c;
-
-    memset(cfg, 0, sizeof(struct config));
-    cfg->threads     = 2;
-    cfg->connections = 10;
-    cfg->duration    = 10;
-    cfg->timeout     = SOCKET_TIMEOUT_MS;
-
-    while ((c = getopt_long(argc, argv, "t:c:d:s:H:T:Lrv?", longopts, NULL)) != -1) {
-        switch (c) {
-            case 't':
-                if (scan_metric(optarg, &cfg->threads)) return -1;
-                break;
-            case 'c':
-                if (scan_metric(optarg, &cfg->connections)) return -1;
-                break;
-            case 'd':
-                if (scan_time(optarg, &cfg->duration)) return -1;
-                break;
-            case 's':
-                cfg->script = optarg;
-                break;
-            case 'H':
-                *header++ = optarg;
-                break;
-            case 'L':
-                cfg->latency = true;
-                break;
-            case 'T':
-                if (scan_time(optarg, &cfg->timeout)) return -1;
-                cfg->timeout *= 1000;
-                break;
-            case 'v':
-                printf("wrk %s [%s] ", VERSION, aeGetApiName());
-                printf("Copyright (C) 2012 Will Glozer\n");
-                break;
-            case 'h':
-            case '?':
-            case ':':
-            default:
-                return -1;
-        }
-    }
-
-    if (optind == argc || !cfg->threads || !cfg->duration) return -1;
-
-    if (!script_parse_url(argv[optind], parts)) {
-        fprintf(stderr, "invalid URL: %s\n", argv[optind]);
-        return -1;
-    }
-
-    if (!cfg->connections || cfg->connections < cfg->threads) {
-        fprintf(stderr, "number of connections must be >= threads\n");
-        return -1;
-    }
-
-    *url    = argv[optind];
-    *header = NULL;
-
-    return 0;
 }
 
 static void print_stats_header() {

--- a/src/wrk.c
+++ b/src/wrk.c
@@ -82,7 +82,7 @@ int main(int argc, char **argv) {
     statistics.requests = stats_alloc(MAX_THREAD_RATE_S);
     thread *threads     = zcalloc(cfg.threads * sizeof(thread));
 
-    lua_State *L = script_create(cfg.script, url, headers);
+    lua_State *L = script_create(cfg.script, url, headers, true);
     if (!script_resolve(L, host, service)) {
         char *msg = strerror(errno);
         fprintf(stderr, "unable to connect to %s:%s %s\n", host, service, msg);
@@ -94,7 +94,7 @@ int main(int argc, char **argv) {
         t->loop        = aeCreateEventLoop(10 + cfg.connections * 3);
         t->connections = cfg.connections / cfg.threads;
 
-        t->L = script_create(cfg.script, url, headers);
+        t->L = script_create(cfg.script, url, headers, true);
         script_init(L, t, argc - optind, &argv[optind]);
 
         if (i == 0) {

--- a/src/wrk.c
+++ b/src/wrk.c
@@ -3,19 +3,9 @@
 #include "wrk.h"
 #include "script.h"
 #include "main.h"
+#include "config.h"
 
-static struct config {
-    uint64_t connections;
-    uint64_t duration;
-    uint64_t threads;
-    uint64_t timeout;
-    uint64_t pipeline;
-    bool     delay;
-    bool     dynamic;
-    bool     latency;
-    char    *script;
-    SSL_CTX *ctx;
-} cfg;
+static struct config cfg;
 
 static struct {
     stats *latency;

--- a/tests/matchers.h
+++ b/tests/matchers.h
@@ -1,0 +1,16 @@
+#ifndef WRK_TESTS_MATCHERS_H
+#define WRK_TESTS_MATCHERS_H
+
+#include <stdbool.h>
+#include <string.h>
+
+/**
+ * Checks if two strings are equal.
+ */
+static bool
+equal_strings(const char* str1, const char* str2)
+{
+	return strcmp(str1, str2) == 0;
+}
+
+#endif /* WRK_TESTS_MATCHERS_H */

--- a/tests/test_base64.c
+++ b/tests/test_base64.c
@@ -1,0 +1,27 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../src/base64.h"
+
+#include "matchers.h"
+
+void
+test_encode_returns_expected_string()
+{
+	const char proxy_auth[] = "user1:password1";
+	char* encoded = base64_encode(proxy_auth, sizeof(proxy_auth) - 1);
+
+	assert(equal_strings(encoded, "dXNlcjE6cGFzc3dvcmQx"));
+
+	free(encoded);
+	encoded = NULL;
+}
+
+int
+main()
+{
+	test_encode_returns_expected_string();
+
+	return 0;
+}

--- a/tests/test_cli_options.c
+++ b/tests/test_cli_options.c
@@ -3,10 +3,23 @@
 #include "../src/cli_options.h"
 #include "../src/config.h"
 #include "../src/http_parser.h"
+#include "../src/zmalloc.h"
 
 #include "matchers.h"
 
 extern int optind;
+
+static int
+parse_config(struct config* cfg, int argc, char* argv[])
+{
+	char* headers[] = {NULL};
+	struct http_parser_url parts = {};
+	char* url = NULL;
+
+	optind = 1;
+	return parse_args(cfg, &url, &parts, headers, argc, argv);
+}
+
 
 static void
 test_parse_args_sets_url()
@@ -29,8 +42,88 @@ test_parse_args_sets_url()
 	assert(equal_strings(url, "http://google.com"));
 }
 
+static void
+test_parse_args_sets_proxy_url_and_port_with_long_option()
+{
+	struct config cfg;
+	char* argv[] = {
+		"wrk",
+		"--proxy",
+		"1.2.3.4:8080",
+		"http://google.com",
+		"\0"
+	};
+	int argc = 4;
+
+	parse_config(&cfg, argc, argv);
+
+	assert(equal_strings(cfg.proxy_addr, "1.2.3.4"));
+	assert(equal_strings(cfg.proxy_port, "8080"));
+}
+
+static void
+test_parse_args_sets_proxy_url_and_port_with_short_option()
+{
+	struct config cfg;
+	char* argv[] = {
+		"wrk",
+		"-x",
+		"1.2.3.4:8080",
+		"http://google.com",
+		"\0"
+	};
+	int argc = 4;
+
+	parse_config(&cfg, argc, argv);
+
+	assert(equal_strings(cfg.proxy_addr, "1.2.3.4"));
+	assert(equal_strings(cfg.proxy_port, "8080"));
+}
+
+static void
+test_parse_args_sets_proxy_user_and_password_with_long_option()
+{
+	struct config cfg;
+	char* argv[] = {
+		"wrk",
+		"--proxy-user",
+		"user-1:password1",
+		"http://google.com",
+		"\0"
+	};
+	int argc = 4;
+
+	parse_config(&cfg, argc, argv);
+
+	assert(equal_strings(cfg.proxy_username, "user-1"));
+	assert(equal_strings(cfg.proxy_user_password, "password1"));
+}
+
+static void
+test_parse_args_sets_proxy_user_and_password_with_short_option()
+{
+	struct config cfg;
+	char* argv[] = {
+		"wrk",
+		"-U",
+		"user-1:password1",
+		"http://google.com",
+		"\0"
+	};
+	int argc = 4;
+
+	parse_config(&cfg, argc, argv);
+
+	assert(equal_strings(cfg.proxy_username, "user-1"));
+	assert(equal_strings(cfg.proxy_user_password, "password1"));
+}
+
 int
 main()
 {
 	test_parse_args_sets_url();
+	test_parse_args_sets_proxy_url_and_port_with_long_option();
+	test_parse_args_sets_proxy_url_and_port_with_short_option();
+	test_parse_args_sets_proxy_user_and_password_with_long_option();
+	test_parse_args_sets_proxy_user_and_password_with_short_option();
 }

--- a/tests/test_cli_options.c
+++ b/tests/test_cli_options.c
@@ -1,0 +1,36 @@
+#include <assert.h>
+
+#include "../src/cli_options.h"
+#include "../src/config.h"
+#include "../src/http_parser.h"
+
+#include "matchers.h"
+
+extern int optind;
+
+static void
+test_parse_args_sets_url()
+{
+	struct config cfg;
+	char* argv[] = {
+		"wrk",
+		"http://google.com",
+		"\0"
+	};
+	int argc = 2;
+
+	char* headers[] = {NULL};
+	struct http_parser_url parts = {};
+	char* url = NULL;
+
+	optind = 1;
+	parse_args(&cfg, &url, &parts, headers, argc, argv);
+
+	assert(equal_strings(url, "http://google.com"));
+}
+
+int
+main()
+{
+	test_parse_args_sets_url();
+}

--- a/tests/test_config.c
+++ b/tests/test_config.c
@@ -1,0 +1,59 @@
+#include <assert.h>
+#include <stdbool.h>
+
+#include "../src/config.h"
+
+void
+test_proxy_set_returns_true_when_proxy_addr_and_port_are_not_empty()
+{
+	struct config cfg = {0};
+	strcpy(cfg.proxy_addr, "1.2.3.4");
+	strcpy(cfg.proxy_port, "8080");
+
+	bool proxy_set = config_proxy_set(&cfg);
+
+	assert(proxy_set == true);
+}
+
+void
+test_proxy_set_returns_false_when_proxy_addr_and_port_are_empty()
+{
+	struct config cfg = {0};
+
+	bool proxy_set = config_proxy_set(&cfg);
+
+	assert(proxy_set == false);
+}
+
+void
+test_proxy_auth_set_returns_false_when_proxy_user_and_password_are_empty()
+{
+	struct config cfg = {0};
+
+	bool auth_set = config_proxy_auth_set(&cfg);
+
+	assert(auth_set == false);
+}
+
+void
+test_proxy_auth_set_returns_true_when_proxy_user_and_password_are_set()
+{
+	struct config cfg = {0};
+	strcpy(cfg.proxy_username, "user1");
+	strcpy(cfg.proxy_user_password, "password1");
+
+	bool auth_set = config_proxy_auth_set(&cfg);
+
+	assert(auth_set == true);
+}
+
+int
+main()
+{
+	test_proxy_set_returns_true_when_proxy_addr_and_port_are_not_empty();
+	test_proxy_set_returns_false_when_proxy_addr_and_port_are_empty();
+	test_proxy_auth_set_returns_false_when_proxy_user_and_password_are_empty();
+	test_proxy_auth_set_returns_true_when_proxy_user_and_password_are_set();
+
+	return 0;
+}

--- a/tests/test_http.c
+++ b/tests/test_http.c
@@ -5,7 +5,6 @@
 
 #include "matchers.h"
 
-
 void
 test_make_proxy_auth_header_returns_header_with_base64_encoded_auth_data()
 {
@@ -18,10 +17,31 @@ test_make_proxy_auth_header_returns_header_with_base64_encoded_auth_data()
 	header = NULL;
 }
 
+void
+test_append_header_adds_specified_header_to_the_end_of_the_list()
+{
+	char header1[] = "header1: value";
+	char** headers = (char**)malloc(3 * sizeof(char*));
+
+	char** it = headers;
+	*it++ = header1;
+	*it++ = NULL;
+	*it = NULL;
+
+	http_append_header(headers, "header2: value");
+
+	char** second_header = headers + 1;
+	assert(equal_strings(*second_header, "header2: value"));
+
+	free(headers);
+	headers = NULL;
+}
+
 int
 main()
 {
 	test_make_proxy_auth_header_returns_header_with_base64_encoded_auth_data();
+	test_append_header_adds_specified_header_to_the_end_of_the_list();
 
 	return 0;
 }

--- a/tests/test_http.c
+++ b/tests/test_http.c
@@ -1,0 +1,27 @@
+#include <assert.h>
+#include <stdlib.h>
+
+#include "../src/http.h"
+
+#include "matchers.h"
+
+
+void
+test_make_proxy_auth_header_returns_header_with_base64_encoded_auth_data()
+{
+	char* header = http_make_proxy_basic_auth_header("user1", "password1");
+
+	assert(equal_strings(header,
+		"Proxy-Authorization: Basic dXNlcjE6cGFzc3dvcmQx"));
+
+	free(header);
+	header = NULL;
+}
+
+int
+main()
+{
+	test_make_proxy_auth_header_returns_header_with_base64_encoded_auth_data();
+
+	return 0;
+}

--- a/tests/test_script.c
+++ b/tests/test_script.c
@@ -10,7 +10,7 @@ test_create_script_sets_appropriate_http_path()
 	char* headers[1] = {NULL};
 	lua_State* lua_vm =
 		script_create(NULL, "http://site.com/test/page1.html", headers,
-			false);
+			false, false);
 
 	lua_getglobal(lua_vm, "wrk");
 	lua_getfield(lua_vm, -1, "path");
@@ -19,10 +19,26 @@ test_create_script_sets_appropriate_http_path()
 	assert(equal_strings(path, "/test/page1.html"));
 }
 
+void
+test_create_script_sets_http_path_same_to_url_when_proxy_is_set()
+{
+	char* headers[1] = {NULL};
+	lua_State* lua_vm =
+		script_create(NULL, "http://site.com/test/page1.html", headers,
+			false, true);
+
+	lua_getglobal(lua_vm, "wrk");
+	lua_getfield(lua_vm, -1, "path");
+
+	const char* path = lua_tostring(lua_vm, -1);
+	assert(equal_strings(path, "http://site.com/test/page1.html"));
+}
+
 int
 main()
 {
 	test_create_script_sets_appropriate_http_path();
+	test_create_script_sets_http_path_same_to_url_when_proxy_is_set();
 
 	return 0;
 }

--- a/tests/test_script.c
+++ b/tests/test_script.c
@@ -1,0 +1,28 @@
+#include <assert.h>
+
+#include "../src/script.h"
+
+#include "matchers.h"
+
+void
+test_create_script_sets_appropriate_http_path()
+{
+	char* headers[1] = {NULL};
+	lua_State* lua_vm =
+		script_create(NULL, "http://site.com/test/page1.html", headers,
+			false);
+
+	lua_getglobal(lua_vm, "wrk");
+	lua_getfield(lua_vm, -1, "path");
+
+	const char* path = lua_tostring(lua_vm, -1);
+	assert(equal_strings(path, "/test/page1.html"));
+}
+
+int
+main()
+{
+	test_create_script_sets_appropriate_http_path();
+
+	return 0;
+}


### PR DESCRIPTION
This PR contains changes that add proxy support for HTTP requests. There will be HTTPS support in the near future.

Changes:

* Added tests and extracted some methods to improve extensibility and maintainability.
* Added `--proxy` and `--proxy-user` CLI options.
* Implemented proxy support:
 * add `Proxy-Auhtorization` header when neded;
 * when proxy is set, change "GET /some/path HTTP 1.1." to "GET http://full.url.com/some/path HTTP 1.1";
** change socket address and port to proxy server.

In general more refactoring must be done: 
inconsistent coding style, unsafe resource (pointer) managing, etc. 