### PR TITLE
Treat zero-length reads as 'remote side closed connection'

### DIFF
--- a/src/wrk.c
+++ b/src/wrk.c
@@ -430,6 +430,9 @@ static void socket_readable(aeEventLoop *loop, int fd, void *data, int mask) {
             case ERROR: goto error;
             case RETRY: return;
         }
+        /* Remote side closed connection */
+        if (n == 0)
+            goto reconnect;
 
         if (http_parser_execute(&c->parser, &parser_settings, c->buf, n) != n) goto error;
         c->thread->bytes += n;
@@ -439,6 +442,7 @@ static void socket_readable(aeEventLoop *loop, int fd, void *data, int mask) {
 
   error:
     c->thread->errors.read++;
+  reconnect:
     reconnect_socket(c->thread, c);
 }
 


### PR DESCRIPTION
When remote side closes connection epoll sets EPOLLIN (and may also set
EPOLLHUP/EPOLLRDHUP). This results in 'wrk' always trying to read from
the socket, but never write to it. Thus, it never detects that the
socket is closed and keeps reading from it forever (consuming 100%).

Signed-off-by: Pavel Borzenkov <pborzenkov@odin.com>