### PR TITLE
thread:set inverts key/value ordering when used with tables

### DIFF
--- a/src/script.c
+++ b/src/script.c
@@ -492,8 +492,8 @@ void script_copy_value(lua_State *src, lua_State *dst, int index) {
             lua_newtable(dst);
             lua_pushnil(src);
             while (lua_next(src, index - 1)) {
-                script_copy_value(src, dst, -1);
                 script_copy_value(src, dst, -2);
+                script_copy_value(src, dst, -1);
                 lua_settable(dst, -3);
                 lua_pop(src, 1);
             }


### PR DESCRIPTION
Test script:

    test_table = {}
    
    function setup(thread)
       if next(test_table) == nil then
          print("creating test_table in", thread)
          table.insert(test_table, "one")
          table.insert(test_table, "two")
          table.insert(test_table, "three")
          test_table.mykey = "myval"
          for key,value in pairs(test_table) do print("setup:", key, value) end
       else
          print(string.format("reusing test_table in %s", thread))
       end
       thread:set("test_table", test_table)
    end
    
    function init(args)
       for key, value in pairs(test_table) do print("init:", key, value) end
    end

Without patch:

    $ wrk -c3 -t3 -s test.lua -d1s http://127.0.0.1:80/
    creating test_table in	userdata: 0x413a5338
    setup:	1	one
    setup:	2	two
    setup:	3	three
    setup:	mykey	myval
    init:	myval	mykey
    init:	three	3
    init:	one	1
    init:	two	2
    reusing test_table in userdata: 0x413a5a98
    init:	myval	mykey
    init:	three	3
    init:	one	1
    init:	two	2
    reusing test_table in userdata: 0x413a5b60
    init:	myval	mykey
    init:	three	3
    init:	one	1
    init:	two	2
    ...

With patch:

    $ wrk -c3 -t3 -s test.lua -d1s http://127.0.0.1:80/
    creating test_table in	userdata: 0x408b9338
    setup:	1	one
    setup:	2	two
    setup:	3	three
    setup:	mykey	myval
    init:	1	one
    init:	2	two
    init:	3	three
    init:	mykey	myval
    reusing test_table in userdata: 0x408b9a98
    init:	1	one
    init:	2	two
    init:	3	three
    init:	mykey	myval
    reusing test_table in userdata: 0x408b9b60
    init:	1	one
    init:	2	two
    init:	3	three
    init:	mykey	myval
    ...