### PR TITLE
Fixed infinite loop when server dropped TCP-connection

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -16,6 +16,9 @@ status sock_close(connection *c) {
 
 status sock_read(connection *c, size_t *n) {
     ssize_t r = read(c->fd, c->buf, sizeof(c->buf));
+    if (r == 0 && errno == EINPROGRESS) {
+        return ERROR;
+    }
     *n = (size_t) r;
     return r >= 0 ? OK : ERROR;
 }


### PR DESCRIPTION
During benchmarks of my current projects I mentioned that in some cases **wrk** begins  consuming 100% of CPU when target HTTP server is dropping TCP connections.
It seems, that wrk has a logical bug in code which lead to infinite loop during reading data from socket.
Here is a piece of strace log: 
```
 epoll_wait(3, {{EPOLLIN, {u32=4, u64=4}}}, 13, 59) = 1
 read(4, "", 8192)                       = 0
 epoll_wait(3, {{EPOLLIN, {u32=4, u64=4}}}, 13, 59) = 1
 read(4, "", 8192)                       = 0
 epoll_wait(3, {{EPOLLIN, {u32=4, u64=4}}}, 13, 59) = 1
```

Steps to reproduce:
1)  Run some web service on 8888 port, e.g.  test_wrk.py
```
import cyclone.web
import sys

from twisted.internet import reactor
from twisted.python import log


class MainHandler(cyclone.web.RequestHandler):
    def get(self):
        self.write("Hello, world")


if __name__ == "__main__":
    application = cyclone.web.Application([
        (r"/", MainHandler)
    ])

    log.startLogging(sys.stdout)
    reactor.listenTCP(8888, application)
    reactor.run()
```
2) Run wrk:
```./wrk -c 1 -t 1 -d 60 http://localhost:8888```
3) Send ctrl+c to  **test_wrk.py**
4) Run test_wrk.py again
5) Use top/htop/ps to see that wrk begins to eat one logical CPU. If you use more than one thread, it may consume all available CPU resources.


With provided patch **wrk** will try to reconnect in described situation. I think, this would be much better, than consuming all CPU resources. It's especially painful, when you try to use **wrk** for long nightly tests.

