### PR TITLE
Custom latency percentiles

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -49,6 +49,6 @@ static char *copy_url_part(char *, struct http_parser_url *, enum http_parser_ur
 
 static void print_stats_header();
 static void print_stats(char *, stats *, char *(*)(long double));
-static void print_stats_latency(stats *);
+static void print_stats_latency(struct config *, stats *);
 
 #endif /* MAIN_H */

--- a/src/stats.c
+++ b/src/stats.c
@@ -78,8 +78,8 @@ long double stats_within_stdev(stats *stats, long double mean, long double stdev
 }
 
 uint64_t stats_percentile(stats *stats, long double p) {
-    uint64_t rank = round((p / 100.0) * stats->count + 0.5);
-    uint64_t total = 0;
+    long double rank = (p / 100.0) * stats->count;
+    long double total = 0;
     for (uint64_t i = stats->min; i <= stats->max; i++) {
         total += stats->data[i];
         if (total >= rank) return i;


### PR DESCRIPTION
Added possibility to specify latency percentiles via command line argument, e.g.

```
$ wrk --latency --latency-percentiles=90,95,99,99.5 http://localhost
Running 10s test @ http://localhost
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.16ms    3.27ms  65.49ms   92.86%
    Req/Sec    22.45k     3.20k   28.39k    80.50%
  Latency Distribution
   90.0%    3.20ms
   95.0%    5.89ms
   99.0%   16.18ms
   99.5%   22.26ms
  446969 requests in 10.01s, 454.37MB read
Requests/sec:  44664.55
Transfer/sec:     45.40MB
```

This branch is mergeable to both `master` and `next`.

Thank you!