### PR TITLE
If darwin include openssl paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ ifeq ($(TARGET), sunos)
 	LIBS   += -lsocket
 else ifeq ($(TARGET), darwin)
 	LDFLAGS += -pagezero_size 10000 -image_base 100000000
+	CFLAGS  += -I/usr/local/opt/openssl/include
+        LIBS    += -L/usr/local/opt/openssl/lib
 else ifeq ($(TARGET), linux)
 	CFLAGS  += -D_POSIX_C_SOURCE=200112L -D_BSD_SOURCE
 	LIBS    += -ldl

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ ifeq ($(TARGET), sunos)
 else ifeq ($(TARGET), darwin)
 	LDFLAGS += -pagezero_size 10000 -image_base 100000000
 	CFLAGS  += -I/usr/local/opt/openssl/include
-        LIBS    += -L/usr/local/opt/openssl/lib
+	LIBS    += -L/usr/local/opt/openssl/lib
 else ifeq ($(TARGET), linux)
 	CFLAGS  += -D_POSIX_C_SOURCE=200112L -D_BSD_SOURCE
 	LIBS    += -ldl


### PR DESCRIPTION
As per the Installing wrk on OSX wiki page, instead of editing the Makefile to include the openssl paths just add them if the target is darwin.