### PR TITLE
Move to TLSv1.2 and turn on SNI

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -6,7 +6,7 @@
 
 #include "net.h"
 
-status sock_connect(connection *c) {
+status sock_connect(connection *c, char *host) {
     return OK;
 }
 

--- a/src/net.h
+++ b/src/net.h
@@ -13,14 +13,14 @@ typedef enum {
 } status;
 
 struct sock {
-    status ( *connect)(connection *);
+    status ( *connect)(connection *, char*);
     status (   *close)(connection *);
     status (    *read)(connection *, size_t *);
     status (   *write)(connection *, char *, size_t, size_t *);
     size_t (*readable)(connection *);
 };
 
-status sock_connect(connection *);
+status sock_connect(connection *, char *);
 status sock_close(connection *);
 status sock_read(connection *, size_t *);
 status sock_write(connection *, char *, size_t, size_t *);

--- a/src/ssl.h
+++ b/src/ssl.h
@@ -5,7 +5,7 @@
 
 SSL_CTX *ssl_init();
 
-status ssl_connect(connection *);
+status ssl_connect(connection *, char *host);
 status ssl_close(connection *);
 status ssl_read(connection *, size_t *);
 status ssl_write(connection *, char *, size_t, size_t *);


### PR DESCRIPTION
This may be best to re-seat on top of #117, and make an optional flag.

I'm using this to performance test a proxy that routes by SNI, so this is very useful (to me at least).

The implementation here isn't perfect, probably wants some changes in the global I introduced and whatnot, but I'm sending it over in this state to get feedback before putting more wrk in.

Thanks for wrk! :heart: