### PR TITLE
Add an option '-r' to limit the number of requests.

### DIFF
--- a/src/ae.c
+++ b/src/ae.c
@@ -75,6 +75,8 @@ aeEventLoop *aeCreateEventLoop(int setsize) {
     eventLoop->stop = 0;
     eventLoop->maxfd = -1;
     eventLoop->beforesleep = NULL;
+    eventLoop->checkThreadStop = NULL;
+    eventLoop->checkThreadStopData = NULL;
     if (aeApiCreate(eventLoop) == -1) goto err;
     /* Events with mask == AE_NONE are not set. So let's initialize the
      * vector with it. */
@@ -386,6 +388,13 @@ int aeProcessEvents(aeEventLoop *eventLoop, int flags)
                     fe->wfileProc(eventLoop,fd,fe->clientData,mask);
             }
             processed++;
+
+            if (eventLoop->checkThreadStop != NULL) {
+                if (eventLoop->checkThreadStop(eventLoop) == 1) {
+                    eventLoop->stop = 1;
+                    break;
+                }
+            }
         }
     }
     /* Check time events */
@@ -432,4 +441,10 @@ char *aeGetApiName(void) {
 
 void aeSetBeforeSleepProc(aeEventLoop *eventLoop, aeBeforeSleepProc *beforesleep) {
     eventLoop->beforesleep = beforesleep;
+}
+
+void aeSetCheckThreadStopProc(aeEventLoop *eventLoop,
+        aeCheckThreadStopProc *checkThreadStop, void *checkData) {
+    eventLoop->checkThreadStop = checkThreadStop;
+    eventLoop->checkThreadStopData = checkData;
 }

--- a/src/ae.h
+++ b/src/ae.h
@@ -57,6 +57,7 @@ typedef void aeFileProc(struct aeEventLoop *eventLoop, int fd, void *clientData,
 typedef int aeTimeProc(struct aeEventLoop *eventLoop, long long id, void *clientData);
 typedef void aeEventFinalizerProc(struct aeEventLoop *eventLoop, void *clientData);
 typedef void aeBeforeSleepProc(struct aeEventLoop *eventLoop);
+typedef int aeCheckThreadStopProc(struct aeEventLoop *eventLoop);
 
 /* File event structure */
 typedef struct aeFileEvent {
@@ -95,6 +96,8 @@ typedef struct aeEventLoop {
     int stop;
     void *apidata; /* This is used for polling API specific data */
     aeBeforeSleepProc *beforesleep;
+    aeCheckThreadStopProc *checkThreadStop;
+    void *checkThreadStopData;
 } aeEventLoop;
 
 /* Prototypes */
@@ -114,5 +117,7 @@ int aeWait(int fd, int mask, long long milliseconds);
 void aeMain(aeEventLoop *eventLoop);
 char *aeGetApiName(void);
 void aeSetBeforeSleepProc(aeEventLoop *eventLoop, aeBeforeSleepProc *beforesleep);
+void aeSetCheckThreadStopProc(aeEventLoop *eventLoop,
+        aeCheckThreadStopProc *checkThreadStop, void *checkData);
 
 #endif

--- a/src/wrk.c
+++ b/src/wrk.c
@@ -120,14 +120,15 @@ int main(int argc, char **argv) {
         }
 
         t->connections = cfg.connections / cfg.threads;
-        t->complete_stop = cfg.requests / cfg.threads;
-        if (i == (cfg.threads - 1))
-            t->complete_stop += (cfg.requests % cfg.threads);
-
         t->L = script_create(cfg.script, url, headers);
         script_init(L, t, argc - optind, &argv[optind]);
 
-        aeSetCheckThreadStopProc(t->loop, aeCheckThreadStop, (void *)t);
+        if (cfg.requests > 0) {
+            t->complete_stop = cfg.requests / cfg.threads;
+            if (i == (cfg.threads - 1))
+                t->complete_stop += (cfg.requests % cfg.threads);
+            aeSetCheckThreadStopProc(t->loop, aeCheckThreadStop, (void *)t);
+        }
 
         if (i == 0) {
             cfg.pipeline = script_verify_request(t->L);

--- a/src/wrk.c
+++ b/src/wrk.c
@@ -8,6 +8,7 @@ static struct config {
     uint64_t connections;
     uint64_t duration;
     uint64_t threads;
+    uint64_t requests;
     uint64_t timeout;
     uint64_t pipeline;
     bool     delay;
@@ -41,12 +42,20 @@ static void handler(int sig) {
     stop = 1;
 }
 
+static int aeCheckThreadStop(struct aeEventLoop *eventLoop) {
+    thread *t = (thread *)eventLoop->checkThreadStopData;
+    if (t->complete == t->complete_stop)
+        return 1;
+    return 0;
+}
+
 static void usage() {
     printf("Usage: wrk <options> <url>                            \n"
            "  Options:                                            \n"
            "    -c, --connections <N>  Connections to keep open   \n"
            "    -d, --duration    <T>  Duration of test           \n"
            "    -t, --threads     <N>  Number of threads to use   \n"
+           "    -r, --requests    <N>  Number of requests to limit\n"
            "                                                      \n"
            "    -s, --script      <S>  Load Lua script file       \n"
            "    -H, --header      <H>  Add header to request      \n"
@@ -102,12 +111,23 @@ int main(int argc, char **argv) {
     cfg.host = host;
 
     for (uint64_t i = 0; i < cfg.threads; i++) {
-        thread *t      = &threads[i];
-        t->loop        = aeCreateEventLoop(10 + cfg.connections * 3);
+        thread *t = &threads[i];
+        t->loop = aeCreateEventLoop(10 + cfg.connections * 3);
+        if (t->loop == NULL) {
+            char *msg = strerror(errno);
+            fprintf(stderr, "unable to create ae eventloop: %s\n", msg);
+            exit(2);
+        }
+
         t->connections = cfg.connections / cfg.threads;
+        t->complete_stop = cfg.requests / cfg.threads;
+        if (i == (cfg.threads - 1))
+            t->complete_stop += (cfg.requests % cfg.threads);
 
         t->L = script_create(cfg.script, url, headers);
         script_init(L, t, argc - optind, &argv[optind]);
+
+        aeSetCheckThreadStopProc(t->loop, aeCheckThreadStop, (void *)t);
 
         if (i == 0) {
             cfg.pipeline = script_verify_request(t->L);
@@ -120,7 +140,7 @@ int main(int argc, char **argv) {
             }
         }
 
-        if (!t->loop || pthread_create(&t->thread, NULL, &thread_main, t)) {
+        if (pthread_create(&t->thread, NULL, &thread_main, t)) {
             char *msg = strerror(errno);
             fprintf(stderr, "unable to create thread %"PRIu64": %s\n", i, msg);
             exit(2);
@@ -143,8 +163,10 @@ int main(int argc, char **argv) {
     uint64_t bytes    = 0;
     errors errors     = { 0 };
 
-    sleep(cfg.duration);
-    stop = 1;
+    if (cfg.duration > 0) {
+        sleep(cfg.duration);
+        stop = 1;
+    }
 
     for (uint64_t i = 0; i < cfg.threads; i++) {
         thread *t = &threads[i];
@@ -470,6 +492,7 @@ static struct option longopts[] = {
     { "connections", required_argument, NULL, 'c' },
     { "duration",    required_argument, NULL, 'd' },
     { "threads",     required_argument, NULL, 't' },
+    { "requests",    required_argument, NULL, 'r' },
     { "script",      required_argument, NULL, 's' },
     { "header",      required_argument, NULL, 'H' },
     { "latency",     no_argument,       NULL, 'L' },
@@ -486,16 +509,20 @@ static int parse_args(struct config *cfg, char **url, struct http_parser_url *pa
     memset(cfg, 0, sizeof(struct config));
     cfg->threads     = 2;
     cfg->connections = 10;
+    cfg->requests    = 0;
     cfg->duration    = 10;
     cfg->timeout     = SOCKET_TIMEOUT_MS;
 
-    while ((c = getopt_long(argc, argv, "t:c:d:s:H:T:Lrv?", longopts, NULL)) != -1) {
+    while ((c = getopt_long(argc, argv, "t:c:r:d:s:H:T:Lrv?", longopts, NULL)) != -1) {
         switch (c) {
             case 't':
                 if (scan_metric(optarg, &cfg->threads)) return -1;
                 break;
             case 'c':
                 if (scan_metric(optarg, &cfg->connections)) return -1;
+                break;
+            case 'r':
+                if (scan_metric(optarg, &cfg->requests)) return -1;
                 break;
             case 'd':
                 if (scan_time(optarg, &cfg->duration)) return -1;
@@ -536,6 +563,12 @@ static int parse_args(struct config *cfg, char **url, struct http_parser_url *pa
         fprintf(stderr, "number of connections must be >= threads\n");
         return -1;
     }
+
+    if (cfg->requests > 0)
+        cfg->duration = 0;
+
+    if (cfg->requests > 0 && cfg->requests < cfg->threads)
+        cfg->threads = cfg->requests;
 
     *url    = argv[optind];
     *header = NULL;

--- a/src/wrk.h
+++ b/src/wrk.h
@@ -36,6 +36,7 @@ typedef struct {
     lua_State *L;
     errors errors;
     struct connection *cs;
+    uint64_t complete_stop;
 } thread;
 
 typedef struct {


### PR DESCRIPTION
Sometimes, some perple want to send fixed requests to the server, and benchmark stoped when all these requests completed. In this case, they care the problem that is how many time to complete all requests. So I add an option '-r' to solve it. For example:
$ wrk -t12 -c400 -r1M http://127.0.0.1:8080/index.html
This runs a benchmark for send 1000000 requests, using 12 threads, and keeping 400 HTTP connections open.
