### PR TITLE
handle EAGAIN errors in sock_read

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -15,9 +15,15 @@ status sock_close(connection *c) {
 }
 
 status sock_read(connection *c, size_t *n) {
-    ssize_t r = read(c->fd, c->buf, sizeof(c->buf));
+    ssize_t r;
+    if ((r = read(c->fd, c->buf, sizeof(c->buf)) == -1) {
+        switch (errno) {
+            case EAGAIN: return RETRY;
+            default:     return ERROR;
+        }
+    }
     *n = (size_t) r;
-    return r >= 0 ? OK : ERROR;
+    return OK;
 }
 
 status sock_write(connection *c, char *buf, size_t len, size_t *n) {


### PR DESCRIPTION
I noticed that if my server couldn't respond immediately, waiting on a callback, then wrk would report read errors. There is code to handle a `RETRY` return value, but `sock_read` wasn't checking for `EAGAIN`.