### PR TITLE
provide LuaLIT jit.* modules to luajit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,10 @@ LDFLAGS += -L$(ODIR)/lib
 ifneq ($(WITH_LUAJIT),)
 	CFLAGS  += -I$(WITH_LUAJIT)/include
 	LDFLAGS += -L$(WITH_LUAJIT)/lib
+	LUA_PATH = $(WITH_LUAJIT)/share/luajit-2.0.4/?.lua
 else
 	DEPS += $(ODIR)/lib/libluajit-5.1.a
+	LUA_PATH = $(ODIR)/LuaJIT-2.0.4/src/?.lua
 endif
 
 ifneq ($(WITH_OPENSSL),)


### PR DESCRIPTION
`luajit -b` requires modules "jit.*". Previously these modules were located
in deps/luajit/src/jit/. Now they are located in obj/LuaJIT-2.0.4/src/jit/
or in /usr/share/luajit-2.0.4/jit/.

This commit fixes the following error:

    LUAJIT src/wrk.lua
    luajit: unknown luaJIT command or jit.* modules not installed
    make: *** [obj/bytecode.o] Error 1