### PR TITLE
fix building with -j > 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,9 @@ ifeq ($(TARGET), darwin)
 else
 	@$(SHELL) -c "cd $< && ./config $(OPENSSL_OPTS)"
 endif
-	@$(MAKE) -C $< depend install
+	@$(MAKE) -C $< depend
+	@$(MAKE) -C $<
+	@$(MAKE) -C $< install
 
 # ------------
 


### PR DESCRIPTION
When combining "depend", "build" and "install" steps, openssl fails
to build in parallel mode because of races between the steps.

If "depend" and "build" are combined, the error is as follows:

```
    cversion.c:62:23: fatal error: buildinf.h: No such file or directory
```

If "build" and "install" are combined, the error is as follows:

```
    installing openssl
    cp: cannot stat 'openssl': No such file or directory
```
