### PR TITLE
Track the total connection count.

### DIFF
--- a/SCRIPTING
+++ b/SCRIPTING
@@ -106,6 +106,7 @@ Done
   summary = {
     duration = N,  -- run duration in microseconds
     requests = N,  -- total completed requests
+    connects = N,  -- total connection attempts
     bytes    = N,  -- total bytes received
     errors   = {
       connect = N, -- total socket connection errors

--- a/src/script.c
+++ b/src/script.c
@@ -209,10 +209,11 @@ void script_header_done(lua_State *L, luaL_Buffer *buffer) {
     luaL_pushresult(buffer);
 }
 
-void script_summary(lua_State *L, uint64_t duration, uint64_t requests, uint64_t bytes) {
+void script_summary(lua_State *L, uint64_t duration, uint64_t requests, uint64_t bytes, uint64_t connects) {
     const table_field fields[] = {
         { "duration", LUA_TNUMBER, &duration },
         { "requests", LUA_TNUMBER, &requests },
+        { "connects", LUA_TNUMBER, &connects },
         { "bytes",    LUA_TNUMBER, &bytes    },
         { NULL,       0,           NULL      },
     };

--- a/src/script.h
+++ b/src/script.h
@@ -25,7 +25,7 @@ bool script_is_static(lua_State *);
 bool script_want_response(lua_State *L);
 bool script_has_delay(lua_State *L);
 bool script_has_done(lua_State *L);
-void script_summary(lua_State *, uint64_t, uint64_t, uint64_t);
+void script_summary(lua_State *, uint64_t, uint64_t, uint64_t, uint64_t);
 void script_errors(lua_State *, errors *);
 
 void script_copy_value(lua_State *, lua_State *, int);

--- a/src/wrk.h
+++ b/src/wrk.h
@@ -31,6 +31,7 @@ typedef struct {
     uint64_t connections;
     uint64_t complete;
     uint64_t requests;
+    uint64_t connects;
     uint64_t bytes;
     uint64_t start;
     lua_State *L;


### PR DESCRIPTION
Track the total connection count across the worker threads. This
makes it more obvious when connection keepalive is being used.

You can use the Lua interface to control the keep alive rate:

``` Lua
count = 0

request = function()
    count = count + 1

    if count % 4 == 0 then
        return wrk.format(nil, nil, {Connection = 'close'})
    else
        return wrk.format(nil, nil, nil)
    end
end
```

The summary output shows the number of connections used:

```
$ ./wrk -s ka.wrk -d 30 -c 10 -t 5 http://www.example.com/
Running 30s test @ http://www.example.com/
  5 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    94.68ms   32.07ms 267.56ms   74.42%
    Req/Sec    17.42      7.55    40.00     57.66%
  2591 requests in 30.09s, 656 connections, 1.54MB read
Requests/sec:     86.10
Requests/conn:     3.95
Transfer/sec:     52.36KB
```
