### PR TITLE
do not create extra requests if there is a reconnect during delays

### DIFF
--- a/src/wrk.h
+++ b/src/wrk.h
@@ -53,6 +53,7 @@ typedef struct connection {
     int fd;
     SSL *ssl;
     bool delayed;
+    bool delay_in_progress;
     uint64_t start;
     char *request;
     size_t length;


### PR DESCRIPTION
If you add a delay that is longer than the connection timeout of
the server, wrk will reconnect, and register a new socket_writeable
callback with the event loop. The problem is, if the delay timer is
running, it will _also_ register a socket_writeable when it wakes up.

For long running tasks, this results in exponential growth in the
number of requests, because socket_writeable is the callback responsible
for registering the delay callbacks.

This is a simple, if somewhat inelegant fix that tracks whether there
is a pending delay timer, and if there is, it does not create a
socket_writeable callback.