### PR TITLE
Adds breakout metrics behind switch

### DIFF
--- a/src/wrk.c
+++ b/src/wrk.c
@@ -13,6 +13,7 @@ static struct config {
     bool     delay;
     bool     dynamic;
     bool     latency;
+    bool     breakout;
     char    *host;
     char    *script;
     SSL_CTX *ctx;
@@ -20,6 +21,9 @@ static struct config {
 
 static struct {
     stats *latency;
+    stats *connect;
+    stats *first_byte;
+    stats *last_byte;
     stats *requests;
 } statistics;
 
@@ -51,6 +55,7 @@ static void usage() {
            "    -s, --script      <S>  Load Lua script file       \n"
            "    -H, --header      <H>  Add header to request      \n"
            "        --latency          Print latency statistics   \n"
+           "        --breakout         Print breakout statistics  \n"
            "        --timeout     <T>  Socket/request timeout     \n"
            "    -v, --version          Print version details      \n"
            "                                                      \n"
@@ -88,9 +93,12 @@ int main(int argc, char **argv) {
     signal(SIGPIPE, SIG_IGN);
     signal(SIGINT,  SIG_IGN);
 
-    statistics.latency  = stats_alloc(cfg.timeout * 1000);
-    statistics.requests = stats_alloc(MAX_THREAD_RATE_S);
-    thread *threads     = zcalloc(cfg.threads * sizeof(thread));
+    statistics.latency      = stats_alloc(cfg.timeout * 1000);
+    statistics.connect      = stats_alloc(cfg.timeout * 1000);
+    statistics.first_byte   = stats_alloc(cfg.timeout * 1000);
+    statistics.last_byte    = stats_alloc(cfg.timeout * 1000);
+    statistics.requests     = stats_alloc(MAX_THREAD_RATE_S);
+    thread *threads         = zcalloc(cfg.threads * sizeof(thread));
 
     lua_State *L = script_create(cfg.script, url, headers);
     if (!script_resolve(L, host, service)) {
@@ -168,11 +176,19 @@ int main(int argc, char **argv) {
     if (complete / cfg.connections > 0) {
         int64_t interval = runtime_us / (complete / cfg.connections);
         stats_correct(statistics.latency, interval);
+        stats_correct(statistics.connect, interval);
+        stats_correct(statistics.first_byte, interval);
+        stats_correct(statistics.last_byte, interval);
     }
 
     print_stats_header();
-    print_stats("Latency", statistics.latency, format_time_us);
-    print_stats("Req/Sec", statistics.requests, format_metric);
+    print_stats("Latency",  statistics.latency, format_time_us);
+    if(cfg.breakout) {
+        print_stats("Connect",  statistics.connect, format_time_us);
+        print_stats("TTFB",     statistics.first_byte, format_time_us);
+        print_stats("TTLB",     statistics.last_byte, format_time_us);
+    }
+    print_stats("Req/Sec",  statistics.requests, format_metric);
     if (cfg.latency) print_stats_latency(statistics.latency);
 
     char *runtime_msg = format_time_us(runtime_us);
@@ -218,6 +234,7 @@ void *thread_main(void *arg) {
         c->request = request;
         c->length  = length;
         c->delayed = cfg.delay;
+        c->requested = c->connect = c->first_byte = c->last_byte = 0;
         connect_socket(thread, c);
     }
 
@@ -237,7 +254,7 @@ static int connect_socket(thread *thread, connection *c) {
     struct addrinfo *addr = thread->addr;
     struct aeEventLoop *loop = thread->loop;
     int fd, flags;
-
+    if(c->requested == 0) c->requested = time_us();
     fd = socket(addr->ai_family, addr->ai_socktype, addr->ai_protocol);
 
     flags = fcntl(fd, F_GETFL, 0);
@@ -370,10 +387,13 @@ static void socket_connected(aeEventLoop *loop, int fd, void *data, int mask) {
 
     http_parser_init(&c->parser, HTTP_RESPONSE);
     c->written = 0;
+    if(c->connect == 0) {
+        c->connect = time_us();
+        stats_record(statistics.connect, c->connect - c->requested);
+    }
 
     aeCreateFileEvent(c->thread->loop, fd, AE_READABLE, socket_readable, c);
     aeCreateFileEvent(c->thread->loop, fd, AE_WRITABLE, socket_writeable, c);
-
     return;
 
   error:
@@ -433,12 +453,18 @@ static void socket_readable(aeEventLoop *loop, int fd, void *data, int mask) {
             case ERROR: goto error;
             case RETRY: return;
         }
-
+        if (c->first_byte == 0) {
+            c->first_byte = time_us();
+            stats_record(statistics.first_byte, c->first_byte - c->connect);
+        }
+        c->last_byte = time_us();
         if (http_parser_execute(&c->parser, &parser_settings, c->buf, n) != n) goto error;
         if (n == 0 && !http_body_is_final(&c->parser)) goto error;
 
         c->thread->bytes += n;
     } while (n == RECVBUF && sock.readable(c) > 0);
+    
+    stats_record(statistics.last_byte, c->last_byte - c->first_byte);
 
     return;
 
@@ -473,6 +499,7 @@ static struct option longopts[] = {
     { "script",      required_argument, NULL, 's' },
     { "header",      required_argument, NULL, 'H' },
     { "latency",     no_argument,       NULL, 'L' },
+    { "breakout",    no_argument,       NULL, 'B' },
     { "timeout",     required_argument, NULL, 'T' },
     { "help",        no_argument,       NULL, 'h' },
     { "version",     no_argument,       NULL, 'v' },
@@ -508,6 +535,9 @@ static int parse_args(struct config *cfg, char **url, struct http_parser_url *pa
                 break;
             case 'L':
                 cfg->latency = true;
+                break;
+            case 'B':
+                cfg->breakout = true;
                 break;
             case 'T':
                 if (scan_time(optarg, &cfg->timeout)) return -1;

--- a/src/wrk.h
+++ b/src/wrk.h
@@ -33,6 +33,10 @@ typedef struct {
     uint64_t requests;
     uint64_t bytes;
     uint64_t start;
+    uint64_t requested;
+    uint64_t connect;
+    uint64_t first_byte;
+    uint64_t last_byte;
     lua_State *L;
     errors errors;
     struct connection *cs;
@@ -54,6 +58,10 @@ typedef struct connection {
     SSL *ssl;
     bool delayed;
     uint64_t start;
+    uint64_t requested;
+    uint64_t connect;
+    uint64_t first_byte;
+    uint64_t last_byte;
     char *request;
     size_t length;
     size_t written;


### PR DESCRIPTION
Hello,

I'd like to see if its possible to add a "--breakout" flag that will show the following new metrics (with rationale behind why its useful):

* connect - the time between a request for a socket started and when a socket was established (includes TLS negotiation/handshake).  This gives an idea how much proxy and TLS handshake negotiations may take.
* ttfb a.k.a. first byte - the time to first byte or the time between the connect happening and the receipt of the first byte of the http protocol (not document).  This gives an idea how much time is spent during the request with the server processing the request then returning an answer.
* ttlb a.k.a. last byte - the time from when the first byte was received to the last byte being received.  This give an idea of the bandwidth.

I'm a bit unsure if my recordings are at appropriate time; the results from running it seem reasonable, with the exception of the time to last byte seems excessively long, but i can't really tell what may cause it.

Can you review and give me some idea how I might improve it; or is it worth while to merge this into wrk?