### PR TITLE
Support luajit 2.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,10 +30,13 @@ DEPS    :=
 CFLAGS  += -I$(ODIR)/include
 LDFLAGS += -L$(ODIR)/lib
 
+WITH_LUAJIT_VERSION ?= luajit-2.0
+
 ifneq ($(WITH_LUAJIT),)
-	CFLAGS  += -I$(WITH_LUAJIT)/include
+	CFLAGS  += -I$(WITH_LUAJIT)/include/$(WITH_LUAJIT_VERSION)
 	LDFLAGS += -L$(WITH_LUAJIT)/lib
 else
+	CFLAGS += -I$(ODIR)/include/luajit-2.0
 	DEPS += $(ODIR)/lib/libluajit-5.1.a
 endif
 

--- a/src/script.c
+++ b/src/script.c
@@ -26,20 +26,20 @@ static void set_fields(lua_State *, int, const table_field *);
 static void set_field(lua_State *, int, char *, int);
 static int push_url_part(lua_State *, char *, struct http_parser_url *, enum http_parser_url_fields);
 
-static const struct luaL_reg addrlib[] = {
+static const struct luaL_Reg addrlib[] = {
     { "__tostring", script_addr_tostring   },
     { "__gc"    ,   script_addr_gc         },
     { NULL,         NULL                   }
 };
 
-static const struct luaL_reg statslib[] = {
+static const struct luaL_Reg statslib[] = {
     { "__call",     script_stats_call      },
     { "__index",    script_stats_index     },
     { "__len",      script_stats_len       },
     { NULL,         NULL                   }
 };
 
-static const struct luaL_reg threadlib[] = {
+static const struct luaL_Reg threadlib[] = {
     { "__index",    script_thread_index    },
     { "__newindex", script_thread_newindex },
     { NULL,         NULL                   }

--- a/src/script.h
+++ b/src/script.h
@@ -2,9 +2,9 @@
 #define SCRIPT_H
 
 #include <stdbool.h>
-#include <luajit-2.0/lua.h>
-#include <luajit-2.0/lualib.h>
-#include <luajit-2.0/lauxlib.h>
+#include <lua.h>
+#include <lualib.h>
+#include <lauxlib.h>
 #include <unistd.h>
 #include "stats.h"
 #include "wrk.h"

--- a/src/wrk.h
+++ b/src/wrk.h
@@ -10,7 +10,7 @@
 
 #include <openssl/ssl.h>
 #include <openssl/err.h>
-#include <luajit-2.0/lua.h>
+#include <lua.h>
 
 #include "stats.h"
 #include "ae.h"


### PR DESCRIPTION
The following set of patches enables support for luajit 2.1.

This is a first step fixing a building issue in Debian unstable, see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=873321
