### PR TITLE
Adding lua script to output results & percentile latency in JSON format

### DIFF
--- a/scripts/json.lua
+++ b/scripts/json.lua
@@ -1,0 +1,26 @@
+-- example reporting script which demonstrates a custom
+-- done() function that prints results as JSON
+
+done = function(summary, latency, requests)
+   io.write("\nJSON Output\n")
+   io.write("-----------\n\n")
+   io.write("{\n")
+   io.write(string.format("\t\"requests\": %d,\n", summary.requests))
+   io.write(string.format("\t\"duration_in_microseconds\": %0.2f,\n", summary.duration))
+   io.write(string.format("\t\"bytes\": %d,\n", summary.bytes))
+   io.write(string.format("\t\"requests_per_sec\": %0.2f,\n", (summary.requests/summary.duration)*1e6))
+   io.write(string.format("\t\"bytes_transfer_per_sec\": %0.2f,\n", (summary.bytes/summary.duration)*1e6))
+   
+   io.write("\t\"latency_distribution\": [\n")
+   for _, p in pairs({ 50, 75, 90, 99, 99.999 }) do
+      io.write("\t\t{\n")
+      n = latency:percentile(p)
+      io.write(string.format("\t\t\t\"percentile\": %g,\n\t\t\t\"latency_in_microseconds\": %d\n", p, n))
+      if p == 99.999 then 
+          io.write("\t\t}\n")
+      else 
+          io.write("\t\t},\n")
+      end
+   end
+   io.write("\t]\n}\n")
+end


### PR DESCRIPTION
This pull request will add a new file `json.lua` to `scripts` directory. This can be used to output results in JSON format as shown below

```
$ ./wrk -c 50 -d 1m -t 2 -s scripts/json.lua http://myserverip -L
Running 1m test @ http://myserverip
  2 threads and 50 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    90.85ms    5.96ms 239.38ms   89.27%
    Req/Sec   275.99     24.69   380.00     75.71%
  Latency Distribution
     50%   90.52ms
     75%   92.73ms
     90%   94.79ms
     99%  110.53ms
  32976 requests in 1.00m, 13.37MB read
Requests/sec:    549.15
Transfer/sec:    227.92KB

JSON Output
-----------

{
	"requests": 32976,
	"duration_in_microseconds": 60048922.00,
	"bytes": 14014800,
	"requests_per_sec": 549.15,
	"bytes_transfer_per_sec": 233389.70,
	"latency_distribution": [
		{
			"percentile": 50,
			"latency_in_microseconds": 90518
		},
		{
			"percentile": 75,
			"latency_in_microseconds": 92727
		},
		{
			"percentile": 90,
			"latency_in_microseconds": 94785
		},
		{
			"percentile": 99,
			"latency_in_microseconds": 110527
		},
		{
			"percentile": 99.999,
			"latency_in_microseconds": 239378
		}
	]
}
```