### PR TITLE
add support for multilib system dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,23 +26,24 @@ ODIR := obj
 OBJ  := $(patsubst %.c,$(ODIR)/%.o,$(SRC)) $(ODIR)/bytecode.o $(ODIR)/version.o
 LIBS := -lluajit-5.1 $(LIBS)
 
+LIB     := lib
 DEPS    :=
 CFLAGS  += -I$(ODIR)/include
 LDFLAGS += -L$(ODIR)/lib
 
 ifneq ($(WITH_LUAJIT),)
 	CFLAGS  += -I$(WITH_LUAJIT)/include
-	LDFLAGS += -L$(WITH_LUAJIT)/lib
+	LDFLAGS += -L$(WITH_LUAJIT)/$(LIB)
 else
 	CFLAGS  += -I$(ODIR)/include/luajit-2.1
-	DEPS    += $(ODIR)/lib/libluajit-5.1.a
+	DEPS    += $(ODIR)/$(LIB)/libluajit-5.1.a
 endif
 
 ifneq ($(WITH_OPENSSL),)
 	CFLAGS  += -I$(WITH_OPENSSL)/include
-	LDFLAGS += -L$(WITH_OPENSSL)/lib
+	LDFLAGS += -L$(WITH_OPENSSL)/$(LIB)
 else
-	DEPS += $(ODIR)/lib/libssl.a
+	DEPS += $(ODIR)/$(LIB)/libssl.a
 endif
 
 all: $(BIN)


### PR DESCRIPTION
On some systems where both 32bit and 64bit versions of a library can
coexist, it is incorrect to assume lib/ for unbundled dependencies.

The $(LIB) variable defaults to "lib" and can for example be changed
to "lib64" on Enterprise Linux and derivatives. The name LIB matches
RPM's convention and could be used in conjunction with the %{_lib}
macro:

    %{make_build} WITH_OPENSSL=/usr WITH_LUAJIT=/usr LIB=%{_lib}

This should ease ports to other platforms.