### PR TITLE
Report : Pretty-Printing 

### DIFF
--- a/scripts/report.lua
+++ b/scripts/report.lua
@@ -3,8 +3,11 @@
 
 done = function(summary, latency, requests)
    io.write("------------------------------\n")
-   for _, p in pairs({ 50, 90, 99, 99.999 }) do
+   io.write("Percentile\t|\tValue\n")
+   io.write("------------------------------\n")
+   for _, p in pairs({ 25, 75, 50, 90, 99, 99.999 }) do
       n = latency:percentile(p)
-      io.write(string.format("%g%%,%d\n", p, n))
+      io.write(string.format("p%g\t\t|\t%d\n", p, n))
    end
+   io.write("------------------------------\n")
 end


### PR DESCRIPTION
## Gist
- Percentiles are rendered using `p25`,  `p99`,  etc.
- Formatting using Tables

> NOTE
Ideally one could use 

* http://lua-users.org/wiki/TableSerialization
* https://github.com/jagt/pprint.lua#usage

## Sample Output

```
$ wrk -s /tmp/report.lua -c 10 -t 8 https://raw.githubusercontent.com/wg/wrk/master/scripts/report.lua
Running 10s test @ https://raw.githubusercontent.com/wg/wrk/master/scripts/report.lua
  8 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    27.44ms    2.56ms  45.17ms   83.18%
    Req/Sec    36.06      5.60    50.00     65.82%
  2883 requests in 10.05s, 3.26MB read
Requests/sec:    286.95
Transfer/sec:    332.55KB
------------------------------
Percentile	|	Value
------------------------------
p25		|	26278
p75		|	28380
p50		|	27334
p90		|	29459
p99		|	36609
p99.999		|	45169
------------------------------
```