### PR TITLE
Start worker threads only after all workers have completed the `setup/init` phase

### DIFF
--- a/src/wrk.c
+++ b/src/wrk.c
@@ -119,6 +119,10 @@ int main(int argc, char **argv) {
                 parser_settings.on_body         = response_body;
             }
         }
+    }
+
+    for (uint64_t i = 0; i < cfg.threads; i++) {
+        thread *t      = &threads[i];
 
         if (!t->loop || pthread_create(&t->thread, NULL, &thread_main, t)) {
             char *msg = strerror(errno);


### PR DESCRIPTION
This simple patch solves #365 