### PR TITLE
Add `tindex` and `tcount` fields to `thread` as the index of the current thread and the total number of threads

### DIFF
--- a/scripts/tdebug.lua
+++ b/scripts/tdebug.lua
@@ -1,0 +1,8 @@
+
+function setup (thread)
+	print ("setup >> " .. thread.tindex .. " of " .. thread.tcount)
+end
+
+function init(x)
+	print ("init  >> " .. wrk.thread.tindex .. " of " .. wrk.thread.tcount)
+end

--- a/src/script.c
+++ b/src/script.c
@@ -419,6 +419,8 @@ static int script_thread_index(lua_State *L) {
     if (!strcmp("set",  key)) lua_pushcfunction(L, script_thread_set);
     if (!strcmp("stop", key)) lua_pushcfunction(L, script_thread_stop);
     if (!strcmp("addr", key)) script_addr_clone(L, t->addr);
+    if (!strcmp("tindex",  key)) lua_pushinteger(L, t->tindex);
+    if (!strcmp("tcount",  key)) lua_pushinteger(L, t->tcount);
     return 1;
 }
 

--- a/src/wrk.c
+++ b/src/wrk.c
@@ -103,6 +103,8 @@ int main(int argc, char **argv) {
 
     for (uint64_t i = 0; i < cfg.threads; i++) {
         thread *t      = &threads[i];
+        t->tindex      = i;
+        t->tcount      = cfg.threads;
         t->loop        = aeCreateEventLoop(10 + cfg.connections * 3);
         t->connections = cfg.connections / cfg.threads;
 

--- a/src/wrk.h
+++ b/src/wrk.h
@@ -25,6 +25,8 @@
 extern const char *VERSION;
 
 typedef struct {
+    int tindex;
+    int tcount;
     pthread_t thread;
     aeEventLoop *loop;
     struct addrinfo *addr;


### PR DESCRIPTION
This small patch exposes to both the `setup` and `init` functions two `thread` attributes:  `tindex` and `tcount` that indicate the current thread "index" and the total number of threads.

It also adds a new `tdebug.lua` script file as an example on how to use them.

---

The main use-case driving this change is the ability to split a large list of URL's between the started threads.  (Without requiring creating extra files already split, etc.)

Namely:
```
local _generated_requests = {}


function init (_arguments)
    for _index, _argument in ipairs (_arguments) do
        _generate_requests (_generated_requests, _argument)
    end
end


function request ()
    local _index = math.random (#_generated_requests)
    return _generated_requests[_index]
end


function _generate_requests (_requests, _path)
    local _tid = wrk.thread.tindex .. "/" .. wrk.thread.tcount
    print ("[ii] [" .. _tid .. "]  loading paths from `" .. _path .. "`...")
    local _index = 0
    local _wrk_path_prefix = wrk.path:gsub ("/$", "")
    for _wrk_path_suffix in io.lines (_path) do
        if math.fmod (_index, wrk.thread.tcount) == wrk.thread.tindex then
            if not _wrk_path_suffix:match ("/$") then
                _wrk_path_suffix = _wrk_path_suffix:gsub ("^/", "")
                _wrk_path = _wrk_path_prefix .. "/" .. _wrk_path_suffix
                _request = wrk.format (wrk.method, _wrk_path, wrk.headers, wrk.body)
                table.insert (_generated_requests, _request)
            end
        end
        _index = _index + 1
    end
    print ("[ii] [" .. _tid .. "]  loaded `" .. #_generated_requests .. '` of `' .. _index .. "` paths.")
end
```

```
[ii] [0/4]  loading paths from `./archives/cdnjs-files.txt`...
[ii] [0/4]  loaded `52634` of `210534` paths.
[ii] [1/4]  loading paths from `./archives/cdnjs-files.txt`...
[ii] [1/4]  loaded `52634` of `210534` paths.
[ii] [2/4]  loading paths from `./archives/cdnjs-files.txt`...
[ii] [2/4]  loaded `52633` of `210534` paths.
[ii] [3/4]  loading paths from `./archives/cdnjs-files.txt`...
[ii] [3/4]  loaded `52633` of `210534` paths.
Running 2m test @ http://172.30.214.38:8080/
  4 threads and 4096 connections
```