### PR TITLE
fix for Windows 10 Linux subsystem installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ $(ODIR):
 
 $(ODIR)/bytecode.o: src/wrk.lua
 	@echo LUAJIT $<
-	@$(SHELL) -c 'PATH=obj/bin:$(PATH) luajit -b $(CURDIR)/$< $(CURDIR)/$@'
+	@$(SHELL) -c 'PATH="obj/bin:$(PATH)" luajit -b $(CURDIR)/$< $(CURDIR)/$@'
 
 $(ODIR)/version.o:
 	@echo 'const char *VERSION="$(VER)";' | $(CC) -xc -c -o $@ -


### PR DESCRIPTION
Hi,
In order to install `wrk` on Windows 10 Linux subsystem, I needed to make a change to `Makefile`,  to handle `PATH` environmental variables that contain spaces and parentheses. 

I am not sure if this might apply to Linux, but it's common to have parentheses inside Windows $PATH variable, for example: `/mnt/c/Program Files (x86)/` inside Linux subsystem.

Before my change, `make` command was failing with the following message:

```bash
LUAJIT src/wrk.lua
/bin/sh: 1: Syntax error: "(" unexpected
Makefile:63: recipe for target 'obj/bytecode.o' failed
```

Adding double quotes fixed the problem, I am able to build and install wrk on 'Bash on Ubuntu on Windows'.
