### PR TITLE
add snapcraft.yaml for building a snap package

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,35 @@
+name: wrk
+version: git
+summary: Modern HTTP benchmarking tool
+description: |
+  wrk is a modern HTTP benchmarking tool capable of generating significant load
+  when run on a single multi-core CPU.
+
+  It combines a multithreaded design with scalable event notification systems
+  such as epoll and kqueue.
+
+  An optional LuaJIT script can perform HTTP request generation, response
+  processing, and custom reporting.
+license: Apache-2.0
+confinement: strict
+grade: stable
+base: core18
+
+apps:
+  wrk:
+    command: bin/wrk
+    plugs:
+      - home
+      - network
+
+parts:
+  wrk:
+    plugin: make
+    source: .
+    source-type: git
+    build-packages:
+      - build-essential
+    artifacts:
+      - wrk
+    organize:
+      wrk: bin/wrk


### PR DESCRIPTION
This adds the `snapcraft.yaml` needed to build a snap package for wrk.

It would be great to have the tool published via build.snapcraft.io