### PR TITLE
Build fix for archs where 64-bit __sync operators are not implemented.

### DIFF
--- a/src/stats.h
+++ b/src/stats.h
@@ -7,6 +7,10 @@
 #define MAX(X, Y) ((X) > (Y) ? (X) : (Y))
 #define MIN(X, Y) ((X) < (Y) ? (X) : (Y))
 
+#if !defined(__ATOMIC_VAR_FORCE_SYNC_MACROS) && defined(__ATOMIC_RELAXED) && !defined(__sun) && (!defined(__clang__) || !defined(__APPLE__) || __apple_build_version__ > 4210057)
+#define __STATS_USE__ATOMIC
+#endif
+
 typedef struct {
     uint32_t connect;
     uint32_t read;


### PR DESCRIPTION
On my OpenBSD/macppc box, wrk fails to build at linking time:

```
stats.c:(.text+0xb20): undefined reference to __sync_fetch_and_add_8
stats.c:(.text+0xb30): undefined reference to __sync_fetch_and_add_8
stats.c:(.text+0xb70): undefined reference to __sync_val_compare_and_swap_8
stats.c:(.text+0xbe4): undefined reference to __sync_val_compare_and_swap_8
```

On some platforms, like ppc32, gcc does not implement legacy 64 `__sync_*` functions, it instead supports `__atomic_*` ones, introduced from gcc-4.8.

I've simply fixed the build by applying the same technique used in `atomicvar.h` where there is already a dual support of `__sync_*` and `__atomic_*`, and used an existing [Debian patch](https://sources.debian.org/patches/wrk/4.0.2-2/debian-changes/), that i've synced against master.

(cc @fcambus)