### PR TITLE
Add p95 into the latency statistics

### DIFF
--- a/src/wrk.c
+++ b/src/wrk.c
@@ -573,7 +573,7 @@ static void print_stats(char *name, stats *stats, char *(*fmt)(long double)) {
 }
 
 static void print_stats_latency(stats *stats) {
-    long double percentiles[] = { 50.0, 75.0, 90.0, 99.0 };
+    long double percentiles[] = { 50.0, 75.0, 90.0, 95.0, 99.0 };
     printf("  Latency Distribution\n");
     for (size_t i = 0; i < sizeof(percentiles) / sizeof(long double); i++) {
         long double p = percentiles[i];


### PR DESCRIPTION
General trend is to capture p90, p95 and p99. 
Added changes to produce output for p95 response time latency stats too. Please review and merge.