### PR TITLE
install target, and warning about invalid -H arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,13 @@ all: $(BIN)
 clean:
 	$(RM) -rf $(BIN) obj/*
 
+DESTDIR=/
+prefix=/usr/local
+
+install: $(BIN)
+	mkdir -p $(DESTDIR)/$(prefix)/bin/
+	cp $(BIN) $(DESTDIR)/$(prefix)/bin/
+
 $(BIN): $(OBJ)
 	@echo LINK $(BIN)
 	@$(CC) $(LDFLAGS) -o $@ $^ $(LIBS)

--- a/src/script.c
+++ b/src/script.c
@@ -86,6 +86,8 @@ lua_State *script_create(char *file, char *url, char **headers) {
             lua_pushlstring(L, *h, p - *h);
             lua_pushstring(L, p + 2);
             lua_settable(L, 5);
+        } else {
+          fprintf(stderr, "invalid -H value: `%s`\n", *h);
         }
     }
     lua_pop(L, 5);


### PR DESCRIPTION
Here's a couple of changes I'm floating locally, easy to keep local, but also pretty unobtrusive, are you interested in either of them?

Having an install target that uses the customary `DESTDIR` and `prefix` vars is helpful when packaging.

The silent discard of -H values lost me some time while bug hunting in the Node.js benchmarks, some warnings would be helpful.

