### PR TITLE
Enclose $PATH in quotes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ $(ODIR):
 
 $(ODIR)/bytecode.o: src/wrk.lua
 	@echo LUAJIT $<
-	@$(SHELL) -c 'PATH=obj/bin:$(PATH) luajit -b $(CURDIR)/$< $(CURDIR)/$@'
+	@$(SHELL) -c 'PATH=obj/bin:"$(PATH)" luajit -b $(CURDIR)/$< $(CURDIR)/$@'
 
 $(ODIR)/version.o:
 	@echo 'const char *VERSION="$(VER)";' | $(CC) -xc -c -o $@ -


### PR DESCRIPTION
Fixes build issue when $PATH contains spaces.