### PR TITLE
make the wrk.headers table case-insensitive

### DIFF
--- a/src/script.c
+++ b/src/script.c
@@ -1,5 +1,6 @@
 // Copyright (C) 2013 - Will Glozer.  All rights reserved.
 
+#include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
 #include "script.h"
@@ -82,9 +83,12 @@ lua_State *script_create(char *file, char *url, char **headers) {
     lua_getfield(L, 4, "headers");
     for (char **h = headers; *h; h++) {
         char *p = strchr(*h, ':');
-        if (p && p[1] == ' ') {
+        if (p) {
             lua_pushlstring(L, *h, p - *h);
-            lua_pushstring(L, p + 2);
+            p++;
+            while (isblank(*p))
+               p++;
+            lua_pushstring(L, p);
             lua_settable(L, 5);
         }
     }

--- a/src/wrk.lua
+++ b/src/wrk.lua
@@ -1,10 +1,19 @@
+local hdr_mt = {
+   __newindex=function(t,k,v)
+      rawset(t,k:lower(),v)
+   end,
+   __index=function(t,k)
+      return rawget(t,k:lower())
+   end
+}
+
 local wrk = {
    scheme  = "http",
    host    = "localhost",
    port    = nil,
    method  = "GET",
    path    = "/",
-   headers = {},
+   headers = setmetatable({}, hdr_mt),
    body    = nil,
    thread  = nil,
 }
@@ -53,6 +62,13 @@ function wrk.format(method, path, headers, body)
    local headers = headers or wrk.headers
    local body    = body    or wrk.body
    local s       = {}
+
+   local tmp = setmetatable({}, hdr_mt)
+   for name, value in pairs(headers) do
+      tmp[name] = value
+   end
+
+   headers = tmp
 
    if not headers["Host"] then
       headers["Host"] = wrk.headers["Host"]


### PR DESCRIPTION
In the HTTP grammar header fields names are case-insensitive, so adding
-Hhost:example.com on the command line would result in a request with
two host headers, leading to a 400 error on web servers that enforce
that HTTP/1.1 requests can only have one host header:

    GET / HTTP/1.1
    Host: 127.0.0.1:8080
    host: example.com

To work around the fact that keys in a lua table are case-sensitive,
the wrk.headers field is wrapped with a case-insensitive metatable. If
a user script passes a headers table, it is also deduplicated via a temp
table since iterating over pairs may result in multiple cases for header
names.

It is possible to have multiple header fields with the same name in an
HTTP request but the recommendation is generally to combine them. It
doesn't work with all headers (for example Accept works, Host doesn't)
and considering how Lua's table works, it's probably simpler to give
up the ability to have multiple headers with the same name to avoid
unintended duplicates.
